### PR TITLE
Merge 11-keys-management-screen into develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,18 @@ Convention plugins in `build-logic/`: `hermes.android.application`, `hermes.andr
 - UI text: Inter. Cryptographic data (hashes, fingerprints): Monospace.
 - Depth via tonal layering, not shadows. No decorative animations.
 
+## Key model — own key vs contacts
+
+The app follows the Kleopatra model: one identity key pair per device (`isSecret = true`), plus unlimited imported contact public keys (`isSecret = false`).
+
+- `GenerateKeyPairUseCase` enforces the one-own-key rule: returns `Result.failure` if an `isSecret = true` key already exists.
+- `ImportPublicKeyUseCase` saves contact keys via `KeyRepository.importPublicKey()` — no private key material involved.
+- `PgpKeyParser` (domain interface) / `BouncyCastlePgpKeyParser` (data impl) parses armored public keys for import.
+- `OnboardingViewModel` checks `keys.any { it.isSecret }` to decide whether to skip onboarding — having only contact keys does not skip it.
+
 ## Watch out for
 
 - Instrumented tests require a connected device or emulator — `connectedAndroidTest` will fail otherwise.
-- Bouncy Castle integration is planned but not yet implemented. Do not assume crypto APIs exist.
+- The Room schema is at version 2. Always write an explicit `Migration` class in `core/data/.../db/migration/` when modifying `PgpKeyEntity` — do not rely on destructive migration.
+- `PgpKeyEntity.encryptedPrivateKeyBlob` and `.privateKeyIv` are nullable — they are null for contact keys (`isSecret = false`).
 - Android Keystore has hardware-backed vs software-backed key behavior differences across API levels.

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysContract.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysContract.kt
@@ -6,14 +6,35 @@ import com.cezila.hermes.core.domain.mvi.UiEvent
 import com.cezila.hermes.core.domain.mvi.UiState
 
 data class KeysUiState(
-    val keys: List<PgpKey> = emptyList(),
+    val ownKey: PgpKey? = null,
+    val contacts: List<PgpKey> = emptyList(),
+    val searchQuery: String = "",
     val isLoading: Boolean = true,
-) : UiState
+    val showFabSheet: Boolean = false,
+) : UiState {
+    val hasKeys: Boolean get() = ownKey != null || contacts.isNotEmpty()
+
+    val filteredContacts: List<PgpKey>
+        get() = if (searchQuery.isBlank()) contacts
+                else contacts.filter { key ->
+                    key.ownerName.contains(searchQuery, ignoreCase = true) ||
+                        key.ownerEmail.contains(searchQuery, ignoreCase = true) ||
+                        key.fingerprint.contains(searchQuery, ignoreCase = true)
+                }
+}
 
 sealed interface KeysUiEvent : UiEvent {
-    data object OnAddKeyClick : KeysUiEvent
+    data class OnSearchQueryChange(val query: String) : KeysUiEvent
+    data object OnFabClick : KeysUiEvent
+    data object OnSheetDismiss : KeysUiEvent
+    data object OnGenerateKeyClick : KeysUiEvent
+    data object OnImportKeyClick : KeysUiEvent
+    data object OnExportOwnKeyClick : KeysUiEvent
+    data object OnExportAllKeysClick : KeysUiEvent
 }
 
 sealed interface KeysUiEffect : UiEffect {
     data object NavigateToKeyGeneration : KeysUiEffect
+    data object NavigateToKeyImport : KeysUiEffect
+    data class SharePublicKey(val armoredText: String) : KeysUiEffect
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysScreen.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysScreen.kt
@@ -1,28 +1,55 @@
 package com.cezila.hermes.presentation.keys
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.material.icons.outlined.IosShare
+import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.cezila.hermes.core.domain.model.PgpKey
 import com.cezila.hermes.core.ui.theme.CryptoFontFamily
@@ -30,55 +57,94 @@ import com.cezila.hermes.core.ui.theme.CryptoFontFamily
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KeysScreen(
-    state: KeysUiState,
-    onEvent: (KeysUiEvent) -> Unit,
+    keysState: KeysUiState,
+    onKeysEvent: (KeysUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(title = { Text("Keys") })
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "VAULT",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = CryptoFontFamily,
+                    )
+                },
+                actions = {
+                    if (keysState.hasKeys) {
+                        if (keysState.ownKey != null) {
+                            IconButton(onClick = { onKeysEvent(KeysUiEvent.OnExportOwnKeyClick) }) {
+                                Icon(
+                                    imageVector = Icons.Outlined.IosShare,
+                                    contentDescription = "Export my public key",
+                                )
+                            }
+                        }
+                        Box {
+                            IconButton(onClick = { showMenu = true }) {
+                                Icon(
+                                    imageVector = Icons.Outlined.MoreVert,
+                                    contentDescription = "More options",
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Export All Public Keys") },
+                                    onClick = {
+                                        showMenu = false
+                                        onKeysEvent(KeysUiEvent.OnExportAllKeysClick)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = { onEvent(KeysUiEvent.OnAddKeyClick) }) {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = "Add key",
-                )
+            if (!keysState.isLoading && keysState.hasKeys) {
+                FloatingActionButton(
+                    onClick = { onKeysEvent(KeysUiEvent.OnFabClick) },
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Add,
+                        contentDescription = "Add key",
+                    )
+                }
             }
         },
+        containerColor = MaterialTheme.colorScheme.background,
     ) { innerPadding ->
         when {
-            state.isLoading -> {
+            keysState.isLoading -> {
                 Box(
-                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
                 }
             }
 
-            state.keys.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize().padding(innerPadding),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(
-                            text = "No keys yet",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Text(
-                            text = "Tap + to generate or import a key",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
+            !keysState.hasKeys -> {
+                EmptyKeysState(
+                    onGenerateClick = { onKeysEvent(KeysUiEvent.OnGenerateKeyClick) },
+                    onImportClick = { onKeysEvent(KeysUiEvent.OnImportKeyClick) },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                )
             }
 
             else -> {
@@ -86,49 +152,353 @@ fun KeysScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(innerPadding),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(state.keys, key = { it.id }) { key ->
-                        KeyListItem(key = key)
-                        HorizontalDivider()
+                    item {
+                        SectionHeader(text = "MY KEY")
+                    }
+
+                    if (keysState.ownKey != null) {
+                        item(key = keysState.ownKey.id) {
+                            OwnKeyCard(key = keysState.ownKey)
+                        }
+                    } else {
+                        item {
+                            GenerateKeyPromptCard(
+                                onClick = { onKeysEvent(KeysUiEvent.OnGenerateKeyClick) },
+                            )
+                        }
+                    }
+
+                    item {
+                        SectionHeader(
+                            text = "CONTACTS",
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                    }
+
+                    if (keysState.contacts.isNotEmpty()) {
+                        item {
+                            OutlinedTextField(
+                                value = keysState.searchQuery,
+                                onValueChange = { onKeysEvent(KeysUiEvent.OnSearchQueryChange(it)) },
+                                placeholder = {
+                                    Text(
+                                        text = "Search contacts",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                },
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+
+                    if (keysState.filteredContacts.isNotEmpty()) {
+                        items(keysState.filteredContacts, key = { it.id }) { key ->
+                            ContactKeyCard(key = key)
+                        }
+                    } else {
+                        item {
+                            EmptyContactsCard(
+                                onClick = { onKeysEvent(KeysUiEvent.OnImportKeyClick) },
+                            )
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    if (keysState.showFabSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { onKeysEvent(KeysUiEvent.OnSheetDismiss) },
+        ) {
+            Column(modifier = Modifier.padding(bottom = 32.dp)) {
+                Text(
+                    text = "Add key",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                val generateDisabled = keysState.ownKey != null
+                val disabledAlpha = 0.38f
+                ListItem(
+                    headlineContent = {
+                        Text(
+                            text = "Generate My Key",
+                            color = MaterialTheme.colorScheme.onSurface.let {
+                                if (generateDisabled) it.copy(alpha = disabledAlpha) else it
+                            },
+                        )
+                    },
+                    supportingContent = {
+                        Text(
+                            text = if (generateDisabled) "You already have an identity key"
+                                   else "Create a new RSA-4096 or Ed25519 key pair",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.let {
+                                if (generateDisabled) it.copy(alpha = disabledAlpha) else it
+                            },
+                        )
+                    },
+                    leadingContent = {
+                        Icon(
+                            imageVector = Icons.Outlined.Key,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface.let {
+                                if (generateDisabled) it.copy(alpha = disabledAlpha) else it
+                            },
+                        )
+                    },
+                    modifier = if (!generateDisabled) {
+                        Modifier.clickable { onKeysEvent(KeysUiEvent.OnGenerateKeyClick) }
+                    } else {
+                        Modifier
+                    },
+                )
+                ListItem(
+                    headlineContent = { Text("Import Contact Key") },
+                    supportingContent = { Text("Add a contact's public key (.asc or paste)") },
+                    leadingContent = {
+                        Icon(
+                            imageVector = Icons.Outlined.FileUpload,
+                            contentDescription = null,
+                        )
+                    },
+                    modifier = Modifier.clickable { onKeysEvent(KeysUiEvent.OnImportKeyClick) },
+                )
             }
         }
     }
 }
 
 @Composable
-private fun KeyListItem(key: PgpKey, modifier: Modifier = Modifier) {
-    ListItem(
-        modifier = modifier.fillMaxWidth(),
-        overlineContent = {
+private fun EmptyKeysState(
+    onGenerateClick: () -> Unit,
+    onImportClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center)
+                .padding(horizontal = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
             Text(
-                text = key.fingerprint,
+                text = "The quiet space for\nyour digital truth.",
+                style = MaterialTheme.typography.displaySmall,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = "Your privacy stays on your device. Start by importing or creating a key.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            androidx.compose.material3.Button(
+                onClick = onGenerateClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = "Generate My Key")
+            }
+            OutlinedButton(
+                onClick = onImportClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = "Import Contact Key")
+            }
+        }
+
+        Text(
+            text = "SECURE INSTANCE  \u2022  NO CLOUD TETHER",
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 24.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        fontFamily = CryptoFontFamily,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.padding(vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun OwnKeyCard(key: PgpKey, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = formatFingerprint(key.fingerprint),
                 fontFamily = CryptoFontFamily,
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
             )
-        },
-        headlineContent = {
             Text(
                 text = key.ownerName,
                 style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onPrimary,
             )
-        },
-        supportingContent = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = key.ownerEmail,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+                )
+                SuggestionChip(
+                    onClick = {},
+                    label = {
+                        Text(
+                            text = key.algorithm.displayName,
+                            fontFamily = CryptoFontFamily,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContactKeyCard(key: PgpKey, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
             Text(
-                text = key.ownerEmail,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-        trailingContent = {
-            Text(
-                text = key.algorithm.displayName,
+                text = formatFingerprint(key.fingerprint),
                 fontFamily = CryptoFontFamily,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        },
-    )
+            Text(
+                text = key.ownerName,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = key.ownerEmail,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                SuggestionChip(
+                    onClick = {},
+                    label = {
+                        Text(
+                            text = key.algorithm.displayName,
+                            fontFamily = CryptoFontFamily,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenerateKeyPromptCard(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    OutlinedCard(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant,
+        ),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 20.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "GENERATE YOUR KEY PAIR",
+                fontFamily = CryptoFontFamily,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyContactsCard(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    OutlinedCard(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant,
+        ),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 20.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "IMPORT A CONTACT KEY",
+                fontFamily = CryptoFontFamily,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun formatFingerprint(fingerprint: String): String {
+    val clean = fingerprint.takeLast(16).uppercase()
+    return clean.chunked(4).joinToString(" ")
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysViewModel.kt
@@ -19,7 +19,15 @@ class KeysViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             getAllKeysUseCase()
-                .onEach { keys -> setState { copy(keys = keys, isLoading = false) } }
+                .onEach { keys ->
+                    setState {
+                        copy(
+                            ownKey = keys.firstOrNull { it.isSecret },
+                            contacts = keys.filter { !it.isSecret },
+                            isLoading = false,
+                        )
+                    }
+                }
                 .catch { setState { copy(isLoading = false) } }
                 .collect {}
         }
@@ -27,7 +35,39 @@ class KeysViewModel @Inject constructor(
 
     override fun handleEvent(event: KeysUiEvent) {
         when (event) {
-            KeysUiEvent.OnAddKeyClick -> sendEffect(KeysUiEffect.NavigateToKeyGeneration)
+            is KeysUiEvent.OnSearchQueryChange ->
+                setState { copy(searchQuery = event.query) }
+
+            KeysUiEvent.OnFabClick ->
+                setState { copy(showFabSheet = true) }
+
+            KeysUiEvent.OnSheetDismiss ->
+                setState { copy(showFabSheet = false) }
+
+            KeysUiEvent.OnGenerateKeyClick -> {
+                setState { copy(showFabSheet = false) }
+                sendEffect(KeysUiEffect.NavigateToKeyGeneration)
+            }
+
+            KeysUiEvent.OnImportKeyClick -> {
+                setState { copy(showFabSheet = false) }
+                sendEffect(KeysUiEffect.NavigateToKeyImport)
+            }
+
+            KeysUiEvent.OnExportOwnKeyClick -> {
+                val armoredKey = currentState.ownKey?.armoredPublicKey
+                if (!armoredKey.isNullOrBlank()) {
+                    sendEffect(KeysUiEffect.SharePublicKey(armoredKey))
+                }
+            }
+
+            KeysUiEvent.OnExportAllKeysClick -> {
+                val allKeys = listOfNotNull(currentState.ownKey) + currentState.contacts
+                val armoredText = allKeys.joinToString("\n\n") { it.armoredPublicKey }
+                if (armoredText.isNotBlank()) {
+                    sendEffect(KeysUiEffect.SharePublicKey(armoredText))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
@@ -1,10 +1,12 @@
 package com.cezila.hermes.presentation.navigation
 
+import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -44,6 +46,11 @@ fun HermesNavHost(
 
                         OnboardingUiEffect.NavigateToKeyGeneration ->
                             navController.navigate(Route.KeyGeneration)
+
+                        OnboardingUiEffect.NavigateToKeys ->
+                            navController.navigate(Route.Keys) {
+                                popUpTo(Route.Onboarding) { inclusive = true }
+                            }
                     }
                 }
             }
@@ -85,22 +92,39 @@ fun HermesNavHost(
         }
 
         composable<Route.Keys> {
-            val viewModel: KeysViewModel = hiltViewModel()
-            val state by viewModel.state.collectAsState()
+            val keysViewModel: KeysViewModel = hiltViewModel()
+            val keysState by keysViewModel.state.collectAsState()
 
-            LaunchedEffect(viewModel) {
-                viewModel.effect.collect { effect ->
+            val context = LocalContext.current
+
+            LaunchedEffect(keysViewModel) {
+                keysViewModel.effect.collect { effect ->
                     when (effect) {
                         KeysUiEffect.NavigateToKeyGeneration ->
                             navController.navigate(Route.KeyGeneration)
+
+                        KeysUiEffect.NavigateToKeyImport ->
+                            navController.navigate(Route.KeyImport)
+
+                        is KeysUiEffect.SharePublicKey -> {
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, effect.armoredText)
+                            }
+                            context.startActivity(Intent.createChooser(intent, null))
+                        }
                     }
                 }
             }
 
             KeysScreen(
-                state = state,
-                onEvent = viewModel::onEvent,
+                keysState = keysState,
+                onKeysEvent = keysViewModel::onEvent,
             )
+        }
+
+        composable<Route.KeyImport> {
+            // TODO Phase 4: Key Import screen
         }
 
         composable<Route.Encrypt> { EncryptScreen() }

--- a/app/src/main/java/com/cezila/hermes/presentation/navigation/Route.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/navigation/Route.kt
@@ -9,4 +9,5 @@ sealed interface Route {
     @Serializable data object Encrypt : Route
     @Serializable data object Decrypt : Route
     @Serializable data object KeyGeneration : Route
+    @Serializable data object KeyImport : Route
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/onboarding/OnboardingContract.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/onboarding/OnboardingContract.kt
@@ -19,4 +19,5 @@ sealed interface OnboardingUiEvent : UiEvent {
 sealed interface OnboardingUiEffect : UiEffect {
     data object NavigateToLearnEncryption : OnboardingUiEffect
     data object NavigateToKeyGeneration : OnboardingUiEffect
+    data object NavigateToKeys : OnboardingUiEffect
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/onboarding/OnboardingViewModel.kt
@@ -1,14 +1,28 @@
 package com.cezila.hermes.presentation.onboarding
 
+import androidx.lifecycle.viewModelScope
+import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
 import com.cezila.hermes.presentation.mvi.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class OnboardingViewModel @Inject constructor() :
-    BaseViewModel<OnboardingUiState, OnboardingUiEvent, OnboardingUiEffect>(
-        initialState = OnboardingUiState(),
-    ) {
+class OnboardingViewModel @Inject constructor(
+    private val getAllKeysUseCase: GetAllKeysUseCase,
+) : BaseViewModel<OnboardingUiState, OnboardingUiEvent, OnboardingUiEffect>(
+    initialState = OnboardingUiState(),
+) {
+
+    init {
+        viewModelScope.launch {
+            val keys = getAllKeysUseCase().first()
+            if (keys.any { it.isSecret }) {
+                sendEffect(OnboardingUiEffect.NavigateToKeys)
+            }
+        }
+    }
 
     override fun handleEvent(event: OnboardingUiEvent) {
         when (event) {

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyParser.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyParser.kt
@@ -1,0 +1,52 @@
+package com.cezila.hermes.core.data.crypto
+
+import com.cezila.hermes.core.domain.crypto.ParsedPublicKeyInfo
+import com.cezila.hermes.core.domain.crypto.PgpKeyParser
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+import org.bouncycastle.util.encoders.Hex
+
+class BouncyCastlePgpKeyParser : PgpKeyParser {
+
+    private val uidRegex = Regex("""^(.+?) <(.+?)>$""")
+
+    override suspend fun parsePublicKey(armoredKey: String): Result<ParsedPublicKeyInfo> = runCatching {
+        val inputStream = PGPUtil.getDecoderStream(armoredKey.byteInputStream(Charsets.UTF_8))
+        val keyRingCollection = PGPPublicKeyRingCollection(inputStream, JcaKeyFingerprintCalculator())
+
+        val keyRing = keyRingCollection.keyRings.asSequence().firstOrNull()
+            ?: throw IllegalArgumentException("No public key ring found in armored input")
+
+        val masterKey: PGPPublicKey = keyRing.publicKeys.asSequence()
+            .firstOrNull { it.isMasterKey }
+            ?: throw IllegalArgumentException("No master key found in key ring")
+
+        val algorithm = KeyAlgorithm.entries.firstOrNull { it.bcAlgorithmTag == masterKey.algorithm }
+            ?: throw IllegalArgumentException("Unsupported key algorithm: ${masterKey.algorithm}")
+
+        val uid = masterKey.userIDs.asSequence().firstOrNull()
+            ?: throw IllegalArgumentException("No user ID found on key")
+
+        val matchResult = uidRegex.matchEntire(uid)
+        val ownerName = matchResult?.groupValues?.get(1)?.trim() ?: uid
+        val ownerEmail = matchResult?.groupValues?.get(2)?.trim() ?: ""
+
+        val fingerprint = Hex.toHexString(masterKey.fingerprint).uppercase()
+        val keyId = "0x${java.lang.Long.toHexString(masterKey.keyID).uppercase().padStart(16, '0')}"
+        val createdAt = masterKey.creationTime.time
+        val expiresAt = if (masterKey.validSeconds > 0) createdAt + masterKey.validSeconds * 1000 else null
+
+        ParsedPublicKeyInfo(
+            fingerprint = fingerprint,
+            keyId = keyId,
+            algorithm = algorithm,
+            ownerName = ownerName,
+            ownerEmail = ownerEmail,
+            createdAt = createdAt,
+            expiresAt = expiresAt,
+        )
+    }
+}

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/HermesDatabase.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/HermesDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 import com.cezila.hermes.core.data.db.dao.PgpKeyDao
 import com.cezila.hermes.core.data.db.entity.PgpKeyEntity
 
-@Database(entities = [PgpKeyEntity::class], version = 1, exportSchema = false)
+@Database(entities = [PgpKeyEntity::class], version = 2, exportSchema = false)
 abstract class HermesDatabase : RoomDatabase() {
     abstract fun pgpKeyDao(): PgpKeyDao
 }

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/entity/PgpKeyEntity.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/entity/PgpKeyEntity.kt
@@ -15,6 +15,6 @@ data class PgpKeyEntity(
     val expiresAt: Long?,
     val isSecret: Boolean,
     val armoredPublicKey: String,
-    val encryptedPrivateKeyBlob: ByteArray,
-    val privateKeyIv: ByteArray,
+    val encryptedPrivateKeyBlob: ByteArray?,
+    val privateKeyIv: ByteArray?,
 )

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/migration/Migration1To2.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/db/migration/Migration1To2.kt
@@ -1,0 +1,30 @@
+package com.cezila.hermes.core.data.db.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // SQLite cannot ALTER COLUMN, so recreate the table with nullable private key fields
+        database.execSQL(
+            """
+            CREATE TABLE pgp_keys_new (
+                id TEXT PRIMARY KEY NOT NULL,
+                fingerprint TEXT NOT NULL,
+                ownerName TEXT NOT NULL,
+                ownerEmail TEXT NOT NULL,
+                algorithmName TEXT NOT NULL,
+                createdAt INTEGER NOT NULL,
+                expiresAt INTEGER,
+                isSecret INTEGER NOT NULL,
+                armoredPublicKey TEXT NOT NULL,
+                encryptedPrivateKeyBlob BLOB,
+                privateKeyIv BLOB
+            )
+            """.trimIndent()
+        )
+        database.execSQL("INSERT INTO pgp_keys_new SELECT * FROM pgp_keys")
+        database.execSQL("DROP TABLE pgp_keys")
+        database.execSQL("ALTER TABLE pgp_keys_new RENAME TO pgp_keys")
+    }
+}

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/CryptoModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/CryptoModule.kt
@@ -1,8 +1,10 @@
 package com.cezila.hermes.core.data.di
 
 import com.cezila.hermes.core.data.crypto.BouncyCastlePgpKeyGenerator
+import com.cezila.hermes.core.data.crypto.BouncyCastlePgpKeyParser
 import com.cezila.hermes.core.data.keystore.KeystoreManager
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
+import com.cezila.hermes.core.domain.crypto.PgpKeyParser
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,4 +22,8 @@ object CryptoModule {
     @Provides
     @Singleton
     fun providePgpKeyGenerator(): PgpKeyGenerator = BouncyCastlePgpKeyGenerator()
+
+    @Provides
+    @Singleton
+    fun providePgpKeyParser(): PgpKeyParser = BouncyCastlePgpKeyParser()
 }

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import com.cezila.hermes.core.data.db.HermesDatabase
 import com.cezila.hermes.core.data.db.dao.PgpKeyDao
+import com.cezila.hermes.core.data.db.migration.MIGRATION_1_2
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,7 +20,7 @@ object DatabaseModule {
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): HermesDatabase =
         Room.databaseBuilder(context, HermesDatabase::class.java, "hermes.db")
-            .fallbackToDestructiveMigration()
+            .addMigrations(MIGRATION_1_2)
             .build()
 
     @Provides

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
@@ -1,9 +1,11 @@
 package com.cezila.hermes.core.data.di
 
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
+import com.cezila.hermes.core.domain.crypto.PgpKeyParser
 import com.cezila.hermes.core.domain.repository.KeyRepository
 import com.cezila.hermes.core.domain.usecase.GenerateKeyPairUseCase
 import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
+import com.cezila.hermes.core.domain.usecase.ImportPublicKeyUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,4 +24,10 @@ object UseCaseModule {
     @Provides
     fun provideGetAllKeysUseCase(keyRepository: KeyRepository): GetAllKeysUseCase =
         GetAllKeysUseCase(keyRepository)
+
+    @Provides
+    fun provideImportPublicKeyUseCase(
+        keyRepository: KeyRepository,
+        pgpKeyParser: PgpKeyParser,
+    ): ImportPublicKeyUseCase = ImportPublicKeyUseCase(keyRepository, pgpKeyParser)
 }

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/repository/KeyRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/repository/KeyRepositoryImpl.kt
@@ -54,6 +54,25 @@ class KeyRepositoryImpl @Inject constructor(
         runCatching { dao.findById(id)?.toDomain() }
     }
 
+    override suspend fun importPublicKey(pgpKey: PgpKey): Result<Unit> = withContext(ioDispatcher) {
+        runCatching {
+            val entity = PgpKeyEntity(
+                id = pgpKey.id,
+                fingerprint = pgpKey.fingerprint,
+                ownerName = pgpKey.ownerName,
+                ownerEmail = pgpKey.ownerEmail,
+                algorithmName = pgpKey.algorithm.name,
+                createdAt = pgpKey.createdAt,
+                expiresAt = pgpKey.expiresAt,
+                isSecret = false,
+                armoredPublicKey = pgpKey.armoredPublicKey,
+                encryptedPrivateKeyBlob = null,
+                privateKeyIv = null,
+            )
+            dao.insert(entity)
+        }
+    }
+
     override suspend fun deleteKey(id: String): Result<Unit> = withContext(ioDispatcher) {
         runCatching {
             dao.deleteById(id)

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/crypto/PgpKeyParser.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/crypto/PgpKeyParser.kt
@@ -1,0 +1,17 @@
+package com.cezila.hermes.core.domain.crypto
+
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+
+data class ParsedPublicKeyInfo(
+    val fingerprint: String,
+    val keyId: String,
+    val algorithm: KeyAlgorithm,
+    val ownerName: String,
+    val ownerEmail: String,
+    val createdAt: Long,
+    val expiresAt: Long?,
+)
+
+interface PgpKeyParser {
+    suspend fun parsePublicKey(armoredKey: String): Result<ParsedPublicKeyInfo>
+}

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/repository/KeyRepository.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/repository/KeyRepository.kt
@@ -10,6 +10,8 @@ interface KeyRepository {
         passphrase: CharArray,
     ): Result<Unit>
 
+    suspend fun importPublicKey(pgpKey: PgpKey): Result<Unit>
+
     fun getAllKeys(): Flow<List<PgpKey>>
 
     suspend fun getKeyById(id: String): Result<PgpKey?>

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/GenerateKeyPairUseCase.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/GenerateKeyPairUseCase.kt
@@ -4,6 +4,7 @@ import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
 import com.cezila.hermes.core.domain.model.KeyAlgorithm
 import com.cezila.hermes.core.domain.model.PgpKey
 import com.cezila.hermes.core.domain.repository.KeyRepository
+import kotlinx.coroutines.flow.first
 
 class GenerateKeyPairUseCase(
     private val keyRepository: KeyRepository,
@@ -17,6 +18,11 @@ class GenerateKeyPairUseCase(
     )
 
     suspend operator fun invoke(params: Params): Result<PgpKey> {
+        val existing = keyRepository.getAllKeys().first()
+        if (existing.any { it.isSecret }) {
+            return Result.failure(IllegalStateException("Own key pair already exists"))
+        }
+
         val materialResult = pgpKeyGenerator.generate(
             ownerName = params.ownerName,
             ownerEmail = params.ownerEmail,

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/ImportPublicKeyUseCase.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/ImportPublicKeyUseCase.kt
@@ -1,0 +1,32 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.crypto.PgpKeyParser
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.repository.KeyRepository
+
+class ImportPublicKeyUseCase(
+    private val keyRepository: KeyRepository,
+    private val pgpKeyParser: PgpKeyParser,
+) {
+    data class Params(val armoredPublicKey: String)
+
+    suspend operator fun invoke(params: Params): Result<PgpKey> {
+        val parsed = pgpKeyParser.parsePublicKey(params.armoredPublicKey)
+            .getOrElse { return Result.failure(it) }
+
+        val pgpKey = PgpKey(
+            id = parsed.keyId,
+            fingerprint = parsed.fingerprint,
+            ownerName = parsed.ownerName,
+            ownerEmail = parsed.ownerEmail,
+            algorithm = parsed.algorithm,
+            createdAt = parsed.createdAt,
+            expiresAt = parsed.expiresAt,
+            isSecret = false,
+            armoredPublicKey = params.armoredPublicKey,
+        )
+
+        keyRepository.importPublicKey(pgpKey).getOrElse { return Result.failure(it) }
+        return Result.success(pgpKey)
+    }
+}

--- a/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/GenerateKeyPairUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/GenerateKeyPairUseCaseTest.kt
@@ -3,10 +3,13 @@ package com.cezila.hermes.core.domain.usecase
 import com.cezila.hermes.core.domain.crypto.GeneratedKeyMaterial
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
 import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import com.cezila.hermes.core.domain.model.PgpKey
 import com.cezila.hermes.core.domain.repository.KeyRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -34,8 +37,21 @@ class GenerateKeyPairUseCaseTest {
         createdAt = 1_700_000_000_000L,
     )
 
+    private val existingOwnKey = PgpKey(
+        id = "0x1122334455667788",
+        fingerprint = "1122334455667788",
+        ownerName = "Bob",
+        ownerEmail = "bob@example.com",
+        algorithm = KeyAlgorithm.RSA_4096,
+        createdAt = 1_600_000_000_000L,
+        expiresAt = null,
+        isSecret = true,
+        armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+    )
+
     @Test
     fun invoke_happyPath_returnsPgpKeyWithCorrectFields() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
         coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns Result.success(Unit)
 
@@ -55,7 +71,32 @@ class GenerateKeyPairUseCaseTest {
     }
 
     @Test
+    fun invoke_ownKeyAlreadyExists_returnsFailureWithoutGenerating() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(existingOwnKey))
+
+        val result = useCase(validParams)
+
+        assertTrue(result.isFailure)
+        assertEquals("Own key pair already exists", result.exceptionOrNull()?.message)
+        coVerify(exactly = 0) { pgpKeyGenerator.generate(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { keyRepository.saveKeyPair(any(), any(), any()) }
+    }
+
+    @Test
+    fun invoke_onlyContactKeysExist_allowsGeneration() = runTest {
+        val contactKey = existingOwnKey.copy(isSecret = false)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(contactKey))
+        coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
+        coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns Result.success(Unit)
+
+        val result = useCase(validParams)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
     fun invoke_generatorFails_returnsFailureWithoutCallingRepository() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns
             Result.failure(RuntimeException("BC error"))
 
@@ -68,6 +109,7 @@ class GenerateKeyPairUseCaseTest {
 
     @Test
     fun invoke_repositorySaveFails_returnsFailure() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
         coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns
             Result.failure(RuntimeException("DB full"))
@@ -80,6 +122,7 @@ class GenerateKeyPairUseCaseTest {
 
     @Test
     fun invoke_passesCorrectParamsToGenerator() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
         coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns Result.success(Unit)
 
@@ -97,6 +140,7 @@ class GenerateKeyPairUseCaseTest {
 
     @Test
     fun invoke_passesArmoredPrivateKeyToRepository() = runTest {
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
         coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns Result.success(Unit)
 
@@ -114,6 +158,7 @@ class GenerateKeyPairUseCaseTest {
     @Test
     fun invoke_withRsaAlgorithm_resultHasRsaAlgorithm() = runTest {
         val rsaParams = validParams.copy(algorithm = KeyAlgorithm.RSA_4096)
+        every { keyRepository.getAllKeys() } returns flowOf(emptyList())
         coEvery { pgpKeyGenerator.generate(any(), any(), any(), any()) } returns Result.success(fakeMaterial)
         coEvery { keyRepository.saveKeyPair(any(), any(), any()) } returns Result.success(Unit)
 

--- a/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/ImportPublicKeyUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/ImportPublicKeyUseCaseTest.kt
@@ -1,0 +1,97 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.crypto.ParsedPublicKeyInfo
+import com.cezila.hermes.core.domain.crypto.PgpKeyParser
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import com.cezila.hermes.core.domain.repository.KeyRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImportPublicKeyUseCaseTest {
+
+    private val keyRepository: KeyRepository = mockk()
+    private val pgpKeyParser: PgpKeyParser = mockk()
+    private val useCase = ImportPublicKeyUseCase(keyRepository, pgpKeyParser)
+
+    private val armoredKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFAKE\n-----END PGP PUBLIC KEY BLOCK-----"
+
+    private val parsedInfo = ParsedPublicKeyInfo(
+        fingerprint = "AABBCCDDEEFF00112233445566778899AABBCCDD",
+        keyId = "0xAABBCCDDEEFF0011",
+        algorithm = KeyAlgorithm.ED25519,
+        ownerName = "Bob",
+        ownerEmail = "bob@example.com",
+        createdAt = 1_700_000_000_000L,
+        expiresAt = null,
+    )
+
+    @Test
+    fun invoke_happyPath_returnsPgpKeyWithIsSecretFalse() = runTest {
+        coEvery { pgpKeyParser.parsePublicKey(armoredKey) } returns Result.success(parsedInfo)
+        coEvery { keyRepository.importPublicKey(any()) } returns Result.success(Unit)
+
+        val result = useCase(ImportPublicKeyUseCase.Params(armoredKey))
+
+        assertTrue(result.isSuccess)
+        val key = result.getOrThrow()
+        assertFalse(key.isSecret)
+        assertEquals(parsedInfo.fingerprint, key.fingerprint)
+        assertEquals(parsedInfo.keyId, key.id)
+        assertEquals("Bob", key.ownerName)
+        assertEquals("bob@example.com", key.ownerEmail)
+        assertEquals(KeyAlgorithm.ED25519, key.algorithm)
+        assertEquals(armoredKey, key.armoredPublicKey)
+    }
+
+    @Test
+    fun invoke_parserFails_returnsFailureWithoutCallingRepository() = runTest {
+        coEvery { pgpKeyParser.parsePublicKey(any()) } returns
+            Result.failure(IllegalArgumentException("Malformed armored key"))
+
+        val result = useCase(ImportPublicKeyUseCase.Params(armoredKey))
+
+        assertTrue(result.isFailure)
+        assertEquals("Malformed armored key", result.exceptionOrNull()?.message)
+        coVerify(exactly = 0) { keyRepository.importPublicKey(any()) }
+    }
+
+    @Test
+    fun invoke_repositoryFails_returnsFailure() = runTest {
+        coEvery { pgpKeyParser.parsePublicKey(armoredKey) } returns Result.success(parsedInfo)
+        coEvery { keyRepository.importPublicKey(any()) } returns
+            Result.failure(RuntimeException("Duplicate key"))
+
+        val result = useCase(ImportPublicKeyUseCase.Params(armoredKey))
+
+        assertTrue(result.isFailure)
+        assertEquals("Duplicate key", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun invoke_passesArmoredKeyToParser() = runTest {
+        coEvery { pgpKeyParser.parsePublicKey(armoredKey) } returns Result.success(parsedInfo)
+        coEvery { keyRepository.importPublicKey(any()) } returns Result.success(Unit)
+
+        useCase(ImportPublicKeyUseCase.Params(armoredKey))
+
+        coVerify { pgpKeyParser.parsePublicKey(armoredKey) }
+    }
+
+    @Test
+    fun invoke_keyWithExpiry_preservesExpiresAt() = runTest {
+        val expiresAt = 1_800_000_000_000L
+        val parsedWithExpiry = parsedInfo.copy(expiresAt = expiresAt)
+        coEvery { pgpKeyParser.parsePublicKey(armoredKey) } returns Result.success(parsedWithExpiry)
+        coEvery { keyRepository.importPublicKey(any()) } returns Result.success(Unit)
+
+        val result = useCase(ImportPublicKeyUseCase.Params(armoredKey))
+
+        assertEquals(expiresAt, result.getOrThrow().expiresAt)
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,29 +57,39 @@ Hermes is a local-first PGP key manager for Android (no backend, no accounts). T
 ---
 
 ### Phase 3: Keys Management (List)
-> Display and manage all stored keys
+> Display and manage all stored keys, distinguishing identity key from contact keys
 
-- Keys list screen with cards (name, email, fingerprint, validity)
-- Search/filter functionality ("Archive Search")
-- "Export All" button (exports all public keys)
-- FAB (+) → navigate to import/generate choice
-- "Import New Identity" card at bottom of list
-- Conditional: if no keys → show Empty State (Phase 1), else → show list
+The app follows the Kleopatra model: one own identity key pair (`isSecret = true`) + unlimited contact public keys (`isSecret = false`).
 
-**Deliverable:** Key list displays generated/imported keys, search works, FAB navigates correctly.
+- Keys list screen with two visual sections:
+  - **My Identity** — the own key pair (if generated). Pinned at the top, distinct visual treatment (e.g. Clay accent). Shows name, email, fingerprint.
+  - **Contacts** — imported contact public keys, each shown as a card (name, email, fingerprint, validity).
+- Search/filter applies across both sections
+- FAB (+) opens a bottom sheet with two choices:
+  - "Generate My Key" — disabled (with tooltip) if an own key already exists
+  - "Import Contact Key" → navigate to import flow (Phase 4)
+- "Export All Public Keys" action in overflow menu
+- Conditional: if no keys at all → show Empty State (Phase 1), else → show list
+
+**Deliverable:** Key list correctly separates identity key from contact keys; FAB enforces the one-own-key rule in the UI.
 
 ---
 
-### Phase 4: Key Import
-> Import existing PGP keys from .asc/.gpg files
+### Phase 4: Contact Key Import
+> Import a contact's public key from armored text or .asc/.gpg file
 
-- **Domain layer:** `ImportKeyUseCase`
-- **Data layer:** File parser for .asc/.gpg formats via Bouncy Castle
-- **Presentation:** Import screen (file picker with 2MB limit, passphrase field, "Import to Vault" button)
-- Android file picker integration (SAF — Storage Access Framework)
-- Validation: file format, size limit, passphrase correctness
+This phase is exclusively for importing **public keys** of other people (`isSecret = false`). It does not handle private key import (out of scope — Hermes generates its own key on-device).
 
-**Deliverable:** User can import an existing PGP key from a file and see it in the key list.
+- **Domain layer:** `ImportPublicKeyUseCase` — parses armored key via `PgpKeyParser`, validates it is a public key, saves via `KeyRepository.importPublicKey()`; returns `Result.failure` if the armored block is invalid or contains a secret key
+- **Data layer:** `BouncyCastlePgpKeyParser` implementation of `PgpKeyParser`; file reader via SAF
+- **Presentation:** Import screen with two input modes:
+  - **Paste armored key** — multiline text field for PGP public key block
+  - **Pick file** — SAF file picker (.asc / .gpg, 2 MB limit)
+  - "Import Contact" button — disabled until valid key is detected
+  - Inline validation feedback (invalid format, secret key detected, duplicate key)
+- No passphrase field — contact keys are public, no passphrase required
+
+**Deliverable:** User can import a contact's public key (paste or file) and see it appear in the Contacts section of the key list.
 
 ---
 


### PR DESCRIPTION
feat(presentation): complete phase 3 keys management screen (#11 )
- add FAB bottom sheet with generate/import options; generate disabled when identity key already exists
- add Clay primary accent to own key card for visual distinction
- add empty state screen when no keys exist
- add Export All Public Keys overflow menu in top app bar
- add ImportPublicKeyUseCase, PgpKeyParser, BouncyCastlePgpKeyParser
- add Room migration 1→2 for nullable private key columns
- wire KeyImport route and update nav graph