### PR TITLE
feat(presentation): add key detail screen with delete and export

### DIFF
--- a/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailContract.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailContract.kt
@@ -1,0 +1,26 @@
+package com.cezila.hermes.presentation.keydetail
+
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.mvi.UiEffect
+import com.cezila.hermes.core.domain.mvi.UiEvent
+import com.cezila.hermes.core.domain.mvi.UiState
+
+data class KeyDetailUiState(
+    val key: PgpKey? = null,
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val showDeleteDialog: Boolean = false,
+) : UiState
+
+sealed interface KeyDetailUiEvent : UiEvent {
+    data object OnBackClick : KeyDetailUiEvent
+    data object OnExportClick : KeyDetailUiEvent
+    data object OnDeleteClick : KeyDetailUiEvent
+    data object OnDeleteConfirm : KeyDetailUiEvent
+    data object OnDeleteDismiss : KeyDetailUiEvent
+}
+
+sealed interface KeyDetailUiEffect : UiEffect {
+    data object NavigateBack : KeyDetailUiEffect
+    data class SharePublicKey(val armoredText: String) : KeyDetailUiEffect
+}

--- a/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailScreen.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailScreen.kt
@@ -1,0 +1,267 @@
+package com.cezila.hermes.presentation.keydetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.ui.theme.CryptoFontFamily
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun KeyDetailScreen(
+    state: KeyDetailUiState,
+    onEvent: (KeyDetailUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "KEY DETAIL",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = CryptoFontFamily,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { onEvent(KeyDetailUiEvent.OnBackClick) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            state.key == null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = state.error ?: "Key not found.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+
+            else -> {
+                KeyDetailContent(
+                    key = state.key,
+                    onEvent = onEvent,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                )
+            }
+        }
+    }
+
+    if (state.showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { onEvent(KeyDetailUiEvent.OnDeleteDismiss) },
+            title = { Text("Delete key?") },
+            text = {
+                Text(
+                    text = "This action cannot be undone. The key will be permanently removed from this device.",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { onEvent(KeyDetailUiEvent.OnDeleteConfirm) },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { onEvent(KeyDetailUiEvent.OnDeleteDismiss) }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun KeyDetailContent(
+    key: PgpKey,
+    onEvent: (KeyDetailUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        Text(
+            text = key.ownerName,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = key.ownerEmail,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        SuggestionChip(
+            onClick = {},
+            label = {
+                Text(
+                    text = key.algorithm.displayName,
+                    fontFamily = CryptoFontFamily,
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            },
+            colors = SuggestionChipDefaults.suggestionChipColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(24.dp))
+
+        MetadataRow(
+            label = "TYPE",
+            value = if (key.isSecret) "My Key" else "Contact",
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "FINGERPRINT",
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = CryptoFontFamily,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = formatFingerprint(key.fingerprint),
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        MetadataRow(
+            label = "CREATED",
+            value = formatDate(key.createdAt),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        MetadataRow(
+            label = "EXPIRES",
+            value = key.expiresAt?.let { formatDate(it) } ?: "No expiration",
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = { onEvent(KeyDetailUiEvent.OnExportClick) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Export Public Key")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedButton(
+            onClick = { onEvent(KeyDetailUiEvent.OnDeleteClick) },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = MaterialTheme.colorScheme.error,
+            ),
+        ) {
+            Text("Delete Key")
+        }
+    }
+}
+
+@Composable
+private fun MetadataRow(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = CryptoFontFamily,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}
+
+private fun formatFingerprint(fingerprint: String): String =
+    fingerprint.uppercase().chunked(4).joinToString(" ")
+
+private fun formatDate(timestamp: Long): String {
+    val sdf = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+    return sdf.format(Date(timestamp * 1000L))
+}

--- a/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keydetail/KeyDetailViewModel.kt
@@ -1,0 +1,72 @@
+package com.cezila.hermes.presentation.keydetail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.cezila.hermes.core.domain.usecase.DeleteKeyUseCase
+import com.cezila.hermes.core.domain.usecase.GetKeyByIdUseCase
+import com.cezila.hermes.presentation.mvi.BaseViewModel
+import com.cezila.hermes.presentation.navigation.Route
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class KeyDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getKeyByIdUseCase: GetKeyByIdUseCase,
+    private val deleteKeyUseCase: DeleteKeyUseCase,
+) : BaseViewModel<KeyDetailUiState, KeyDetailUiEvent, KeyDetailUiEffect>(
+    initialState = KeyDetailUiState(),
+) {
+
+    private val keyId: String = savedStateHandle.toRoute<Route.KeyDetail>().keyId
+
+    init {
+        loadKey()
+    }
+
+    private fun loadKey() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getKeyByIdUseCase(keyId)
+                .onSuccess { key ->
+                    setState { copy(key = key, isLoading = false) }
+                }
+                .onFailure { error ->
+                    setState { copy(isLoading = false, error = error.message) }
+                }
+        }
+    }
+
+    override fun handleEvent(event: KeyDetailUiEvent) {
+        when (event) {
+            KeyDetailUiEvent.OnBackClick ->
+                sendEffect(KeyDetailUiEffect.NavigateBack)
+
+            KeyDetailUiEvent.OnExportClick -> {
+                val armoredKey = currentState.key?.armoredPublicKey
+                if (!armoredKey.isNullOrBlank()) {
+                    sendEffect(KeyDetailUiEffect.SharePublicKey(armoredKey))
+                }
+            }
+
+            KeyDetailUiEvent.OnDeleteClick ->
+                setState { copy(showDeleteDialog = true) }
+
+            KeyDetailUiEvent.OnDeleteDismiss ->
+                setState { copy(showDeleteDialog = false) }
+
+            KeyDetailUiEvent.OnDeleteConfirm -> {
+                setState { copy(showDeleteDialog = false) }
+                viewModelScope.launch(Dispatchers.IO) {
+                    deleteKeyUseCase(keyId)
+                        .onSuccess { sendEffect(KeyDetailUiEffect.NavigateBack) }
+                        .onFailure { error ->
+                            setState { copy(error = error.message) }
+                        }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysContract.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysContract.kt
@@ -31,10 +31,12 @@ sealed interface KeysUiEvent : UiEvent {
     data object OnImportKeyClick : KeysUiEvent
     data object OnExportOwnKeyClick : KeysUiEvent
     data object OnExportAllKeysClick : KeysUiEvent
+    data class OnKeyCardClick(val keyId: String) : KeysUiEvent
 }
 
 sealed interface KeysUiEffect : UiEffect {
     data object NavigateToKeyGeneration : KeysUiEffect
     data object NavigateToKeyImport : KeysUiEffect
     data class SharePublicKey(val armoredText: String) : KeysUiEffect
+    data class NavigateToKeyDetail(val keyId: String) : KeysUiEffect
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysScreen.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysScreen.kt
@@ -161,7 +161,10 @@ fun KeysScreen(
 
                     if (keysState.ownKey != null) {
                         item(key = keysState.ownKey.id) {
-                            OwnKeyCard(key = keysState.ownKey)
+                            OwnKeyCard(
+                                key = keysState.ownKey,
+                                onClick = { onKeysEvent(KeysUiEvent.OnKeyCardClick(keysState.ownKey.id)) },
+                            )
                         }
                     } else {
                         item {
@@ -198,7 +201,10 @@ fun KeysScreen(
 
                     if (keysState.filteredContacts.isNotEmpty()) {
                         items(keysState.filteredContacts, key = { it.id }) { key ->
-                            ContactKeyCard(key = key)
+                            ContactKeyCard(
+                                key = key,
+                                onClick = { onKeysEvent(KeysUiEvent.OnKeyCardClick(key.id)) },
+                            )
                         }
                     } else {
                         item {
@@ -339,8 +345,9 @@ private fun SectionHeader(text: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun OwnKeyCard(key: PgpKey, modifier: Modifier = Modifier) {
+private fun OwnKeyCard(key: PgpKey, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Card(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primary,
@@ -393,8 +400,9 @@ private fun OwnKeyCard(key: PgpKey, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ContactKeyCard(key: PgpKey, modifier: Modifier = Modifier) {
+private fun ContactKeyCard(key: PgpKey, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Card(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/app/src/main/java/com/cezila/hermes/presentation/keys/KeysViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keys/KeysViewModel.kt
@@ -68,6 +68,9 @@ class KeysViewModel @Inject constructor(
                     sendEffect(KeysUiEffect.SharePublicKey(armoredText))
                 }
             }
+
+            is KeysUiEvent.OnKeyCardClick ->
+                sendEffect(KeysUiEffect.NavigateToKeyDetail(event.keyId))
         }
     }
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
@@ -13,6 +13,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.cezila.hermes.presentation.decrypt.DecryptScreen
 import com.cezila.hermes.presentation.encrypt.EncryptScreen
+import com.cezila.hermes.presentation.keydetail.KeyDetailScreen
+import com.cezila.hermes.presentation.keydetail.KeyDetailUiEffect
+import com.cezila.hermes.presentation.keydetail.KeyDetailViewModel
 import com.cezila.hermes.presentation.keygeneration.KeyGenerationScreen
 import com.cezila.hermes.presentation.keygeneration.KeyGenerationUiEffect
 import com.cezila.hermes.presentation.keygeneration.KeyGenerationViewModel
@@ -116,6 +119,9 @@ fun HermesNavHost(
                             }
                             context.startActivity(Intent.createChooser(intent, null))
                         }
+
+                        is KeysUiEffect.NavigateToKeyDetail ->
+                            navController.navigate(Route.KeyDetail(effect.keyId))
                     }
                 }
             }
@@ -140,6 +146,32 @@ fun HermesNavHost(
             }
 
             KeyImportScreen(
+                state = state,
+                onEvent = viewModel::onEvent,
+            )
+        }
+
+        composable<Route.KeyDetail> {
+            val viewModel: KeyDetailViewModel = hiltViewModel()
+            val state by viewModel.state.collectAsState()
+            val context = LocalContext.current
+
+            LaunchedEffect(viewModel) {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        KeyDetailUiEffect.NavigateBack -> navController.popBackStack()
+                        is KeyDetailUiEffect.SharePublicKey -> {
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, effect.armoredText)
+                            }
+                            context.startActivity(Intent.createChooser(intent, null))
+                        }
+                    }
+                }
+            }
+
+            KeyDetailScreen(
                 state = state,
                 onEvent = viewModel::onEvent,
             )

--- a/app/src/main/java/com/cezila/hermes/presentation/navigation/Route.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/navigation/Route.kt
@@ -10,4 +10,5 @@ sealed interface Route {
     @Serializable data object Decrypt : Route
     @Serializable data object KeyGeneration : Route
     @Serializable data object KeyImport : Route
+    @Serializable data class KeyDetail(val keyId: String) : Route
 }

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
@@ -3,8 +3,10 @@ package com.cezila.hermes.core.data.di
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
 import com.cezila.hermes.core.domain.crypto.PgpKeyParser
 import com.cezila.hermes.core.domain.repository.KeyRepository
+import com.cezila.hermes.core.domain.usecase.DeleteKeyUseCase
 import com.cezila.hermes.core.domain.usecase.GenerateKeyPairUseCase
 import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
+import com.cezila.hermes.core.domain.usecase.GetKeyByIdUseCase
 import com.cezila.hermes.core.domain.usecase.ImportPublicKeyUseCase
 import dagger.Module
 import dagger.Provides
@@ -30,4 +32,12 @@ object UseCaseModule {
         keyRepository: KeyRepository,
         pgpKeyParser: PgpKeyParser,
     ): ImportPublicKeyUseCase = ImportPublicKeyUseCase(keyRepository, pgpKeyParser)
+
+    @Provides
+    fun provideGetKeyByIdUseCase(keyRepository: KeyRepository): GetKeyByIdUseCase =
+        GetKeyByIdUseCase(keyRepository)
+
+    @Provides
+    fun provideDeleteKeyUseCase(keyRepository: KeyRepository): DeleteKeyUseCase =
+        DeleteKeyUseCase(keyRepository)
 }

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/DeleteKeyUseCase.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/DeleteKeyUseCase.kt
@@ -1,0 +1,9 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.repository.KeyRepository
+
+class DeleteKeyUseCase(
+    private val keyRepository: KeyRepository,
+) {
+    suspend operator fun invoke(id: String): Result<Unit> = keyRepository.deleteKey(id)
+}

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/GetKeyByIdUseCase.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/GetKeyByIdUseCase.kt
@@ -1,0 +1,10 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.repository.KeyRepository
+
+class GetKeyByIdUseCase(
+    private val keyRepository: KeyRepository,
+) {
+    suspend operator fun invoke(id: String): Result<PgpKey?> = keyRepository.getKeyById(id)
+}


### PR DESCRIPTION
## Summary
Implements the key detail screen, accessible by tapping any key card in the keys list. The screen shows full key metadata and supports exporting the public key and deleting the key with a confirmation dialog.

## Changes
- `GetKeyByIdUseCase` and `DeleteKeyUseCase` added to domain layer
- `KeyDetailScreen` / `KeyDetailViewModel` / `KeyDetailContract` — full MVI screen with loading, error, export, and delete-with-confirmation states
- `KeysScreen` cards now trigger navigation to key detail on tap
- `KeyDetail` route added to `Route` sealed interface and wired in `HermesNavHost`
- DI bindings for the two new use cases in `UseCaseModule`

Closes #15