### PR TITLE
Merge feat/19-pgp-decrypt-verify-screen into develop

### DIFF
--- a/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptContract.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptContract.kt
@@ -1,0 +1,54 @@
+package com.cezila.hermes.presentation.decrypt
+
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.mvi.UiEffect
+import com.cezila.hermes.core.domain.mvi.UiEvent
+import com.cezila.hermes.core.domain.mvi.UiState
+
+data class DecryptUiState(
+    val ownKey: PgpKey? = null,
+    val allKeys: List<PgpKey> = emptyList(),
+    val inputMode: InputMode = InputMode.TEXT,
+    val ciphertextInput: String = "",
+    val headerStatus: HeaderStatus = HeaderStatus.Awaiting,
+    val selectedFileBytes: ByteArray? = null,
+    val selectedFileName: String? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val showPassphraseDialog: Boolean = false,
+    val decryptionResult: DecryptionResult? = null,
+) : UiState {
+    val canDecrypt: Boolean
+        get() = ownKey != null &&
+            (inputMode == InputMode.TEXT && headerStatus == HeaderStatus.Valid ||
+                inputMode == InputMode.FILE && selectedFileBytes != null)
+}
+
+enum class InputMode { TEXT, FILE }
+
+enum class HeaderStatus { Awaiting, Valid, Invalid }
+
+sealed interface DecryptUiEvent : UiEvent {
+    data class OnCiphertextChanged(val text: String) : DecryptUiEvent
+    data object OnPasteFromClipboard : DecryptUiEvent
+    data object OnClearInput : DecryptUiEvent
+    data class OnFileSelected(val bytes: ByteArray, val name: String) : DecryptUiEvent
+    data object OnClearFile : DecryptUiEvent
+    data class OnInputModeChanged(val mode: InputMode) : DecryptUiEvent
+    data object OnDecryptClick : DecryptUiEvent
+    data class OnPassphraseConfirmed(val passphrase: CharArray) : DecryptUiEvent
+    data object OnPassphraseDismissed : DecryptUiEvent
+    data object OnCopyPlaintext : DecryptUiEvent
+    data object OnSaveDecryptedFile : DecryptUiEvent
+    data object OnDismissResult : DecryptUiEvent
+    data object OnDismissError : DecryptUiEvent
+}
+
+sealed interface DecryptUiEffect : UiEffect {
+    data object PickFile : DecryptUiEffect
+    data class SaveDecryptedFile(val bytes: ByteArray, val suggestedName: String) : DecryptUiEffect
+    data class CopyToClipboard(val text: String) : DecryptUiEffect
+    data class ShowToast(val message: String) : DecryptUiEffect
+    data object RequestClipboardRead : DecryptUiEffect
+}

--- a/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptScreen.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptScreen.kt
@@ -1,23 +1,688 @@
 package com.cezila.hermes.presentation.decrypt
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.model.SignatureStatus
+import com.cezila.hermes.core.ui.theme.Clay
+import com.cezila.hermes.core.ui.theme.CryptoFontFamily
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DecryptScreen(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = "Decrypt",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onBackground,
+fun DecryptScreen(
+    state: DecryptUiState,
+    onEvent: (DecryptUiEvent) -> Unit,
+    onPickFile: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state.showPassphraseDialog) {
+        PassphraseBottomSheet(
+            onConfirm = { passphrase -> onEvent(DecryptUiEvent.OnPassphraseConfirmed(passphrase)) },
+            onDismiss = { onEvent(DecryptUiEvent.OnPassphraseDismissed) },
         )
     }
+
+    if (state.decryptionResult != null) {
+        val resolvedSigner = remember(state.decryptionResult, state.allKeys) {
+            resolveSignerKey(state.decryptionResult.signatureStatus, state.allKeys)
+        }
+        DecryptionResultBottomSheet(
+            result = state.decryptionResult,
+            resolvedSigner = resolvedSigner,
+            onCopyPlaintext = { onEvent(DecryptUiEvent.OnCopyPlaintext) },
+            onSaveFile = { onEvent(DecryptUiEvent.OnSaveDecryptedFile) },
+            onDismiss = { onEvent(DecryptUiEvent.OnDismissResult) },
+        )
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "HERMES",
+                        fontFamily = CryptoFontFamily,
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                },
+                actions = {
+                    Icon(
+                        imageVector = Icons.Outlined.Person,
+                        contentDescription = "Profile",
+                        modifier = Modifier.padding(end = 12.dp),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // Hero section
+            Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+                Text(
+                    text = "Decode your\nmessage.",
+                    style = MaterialTheme.typography.displaySmall.copy(
+                        fontWeight = FontWeight.Bold,
+                        lineHeight = 44.sp,
+                    ),
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Decrypt and cryptographically verify the\norigin of a PGP-secured payload.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Mode toggle
+            Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                Text(
+                    text = "INPUT MODE",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    letterSpacing = 1.sp,
+                )
+                Spacer(Modifier.height(8.dp))
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    InputMode.entries.forEachIndexed { index, mode ->
+                        SegmentedButton(
+                            selected = state.inputMode == mode,
+                            onClick = { onEvent(DecryptUiEvent.OnInputModeChanged(mode)) },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = InputMode.entries.size,
+                            ),
+                            enabled = !state.isLoading,
+                        ) {
+                            Text(mode.name)
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Input panel
+            when (state.inputMode) {
+                InputMode.TEXT -> TextInputPanel(state = state, onEvent = onEvent)
+                InputMode.FILE -> FileInputPanel(state = state, onEvent = onEvent, onPickFile = onPickFile)
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Session details
+            Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                OutlinedCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Text(
+                            text = "TRANSMISSION DETAILS",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontFamily = CryptoFontFamily,
+                            letterSpacing = 1.sp,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        SessionDetailRow(label = "Protocol", value = "OpenPGP v4")
+                        SessionDetailRow(label = "Runtime", value = "Client-Side Only")
+                    }
+                }
+            }
+
+            if (state.error != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = state.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                )
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Decrypt & Verify CTA
+            Button(
+                onClick = { onEvent(DecryptUiEvent.OnDecryptClick) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                enabled = state.canDecrypt && !state.isLoading,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Clay,
+                    contentColor = Color.White,
+                    disabledContainerColor = Clay.copy(alpha = 0.38f),
+                    disabledContentColor = Color.White.copy(alpha = 0.6f),
+                ),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.LockOpen,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+                Text(
+                    text = "Decrypt & Verify",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+
+            // Footer
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "SECURE INSTANCE — NO CLOUD TETHER",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontFamily = CryptoFontFamily,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                letterSpacing = 0.5.sp,
+            )
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun TextInputPanel(
+    state: DecryptUiState,
+    onEvent: (DecryptUiEvent) -> Unit,
+) {
+    Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "PGP MESSAGE",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                letterSpacing = 1.sp,
+            )
+            Row {
+                TextButton(
+                    onClick = { onEvent(DecryptUiEvent.OnPasteFromClipboard) },
+                    enabled = !state.isLoading,
+                ) {
+                    Text(
+                        text = "PASTE",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = CryptoFontFamily,
+                    )
+                }
+                TextButton(
+                    onClick = { onEvent(DecryptUiEvent.OnClearInput) },
+                    enabled = state.ciphertextInput.isNotBlank() && !state.isLoading,
+                ) {
+                    Text(
+                        text = "CLEAR",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontFamily = CryptoFontFamily,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = state.ciphertextInput,
+            onValueChange = { onEvent(DecryptUiEvent.OnCiphertextChanged(it)) },
+            placeholder = {
+                Text(
+                    "Paste PGP message here…",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp),
+            textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            maxLines = Int.MAX_VALUE,
+            enabled = !state.isLoading,
+        )
+
+        Spacer(Modifier.height(6.dp))
+
+        // Header status badge
+        val (statusText, statusColor) = when (state.headerStatus) {
+            HeaderStatus.Awaiting -> "AWAITING VALID HEADER…" to MaterialTheme.colorScheme.onSurfaceVariant
+            HeaderStatus.Valid -> "VALID PGP MESSAGE" to Clay
+            HeaderStatus.Invalid -> "INVALID FORMAT" to MaterialTheme.colorScheme.error
+        }
+        Text(
+            text = statusText,
+            style = MaterialTheme.typography.labelSmall,
+            color = statusColor,
+            fontFamily = CryptoFontFamily,
+            letterSpacing = 0.5.sp,
+        )
+    }
+}
+
+@Composable
+private fun FileInputPanel(
+    state: DecryptUiState,
+    onEvent: (DecryptUiEvent) -> Unit,
+    onPickFile: () -> Unit,
+) {
+    Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+        Text(
+            text = "ENCRYPTED FILE",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            letterSpacing = 1.sp,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        if (state.selectedFileName != null) {
+            OutlinedCard(
+                modifier = Modifier.fillMaxWidth(),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Folder,
+                        contentDescription = null,
+                        tint = Clay,
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = state.selectedFileName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    IconButton(
+                        onClick = { onEvent(DecryptUiEvent.OnClearFile) },
+                        enabled = !state.isLoading,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = "Remove file",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        } else {
+            OutlinedCard(
+                onClick = onPickFile,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !state.isLoading,
+                border = BorderStroke(
+                    1.dp,
+                    MaterialTheme.colorScheme.outlineVariant,
+                ),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Folder,
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "Encrypted File",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "Tap to pick a .pgp or .gpg file",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SessionDetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = CryptoFontFamily,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PassphraseBottomSheet(
+    onConfirm: (CharArray) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var passphrase by remember { mutableStateOf("") }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "Enter Passphrase",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "Required to unlock your identity key for decryption.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = passphrase,
+                onValueChange = { passphrase = it },
+                label = { Text("Passphrase") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = {
+                    passphrase = ""
+                    onDismiss()
+                }) {
+                    Text("Cancel")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = {
+                        val chars = passphrase.toCharArray()
+                        passphrase = ""
+                        onConfirm(chars)
+                    },
+                    enabled = passphrase.isNotEmpty(),
+                    colors = ButtonDefaults.buttonColors(containerColor = Clay),
+                ) {
+                    Text("Confirm", color = Color.White)
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DecryptionResultBottomSheet(
+    result: DecryptionResult,
+    resolvedSigner: PgpKey?,
+    onCopyPlaintext: () -> Unit,
+    onSaveFile: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Decrypted Message",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            // Signature status
+            SignatureStatusBadge(status = result.signatureStatus, resolvedSigner = resolvedSigner)
+
+            // Plaintext display (text mode only)
+            if (result.plaintext.isNotBlank()) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = MaterialTheme.shapes.medium,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .padding(12.dp)
+                            .verticalScroll(rememberScrollState()),
+                    ) {
+                        Text(
+                            text = result.plaintext,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // File display (file mode)
+            if (result.plaintextBytes != null) {
+                OutlinedCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Folder,
+                            contentDescription = null,
+                            tint = Clay,
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = result.fileName ?: "decrypted_file",
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = "${result.plaintextBytes!!.size} bytes",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Actions
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (result.plaintext.isNotBlank()) {
+                    Button(
+                        onClick = onCopyPlaintext,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(containerColor = Clay),
+                    ) {
+                        Text("Copy", color = Color.White)
+                    }
+                }
+                if (result.plaintextBytes != null) {
+                    Button(
+                        onClick = onSaveFile,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(containerColor = Clay),
+                    ) {
+                        Text("Save File", color = Color.White)
+                    }
+                }
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Done")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SignatureStatusBadge(
+    status: SignatureStatus,
+    resolvedSigner: PgpKey?,
+) {
+    val (text, color) = when (status) {
+        is SignatureStatus.Valid -> {
+            val signerDisplay = resolvedSigner?.let { "${it.ownerName} <${it.ownerEmail}>" }
+                ?: status.signerKeyId
+            "VERIFIED — $signerDisplay" to Clay
+        }
+        is SignatureStatus.Invalid ->
+            "SIGNATURE INVALID" to MaterialTheme.colorScheme.error
+        is SignatureStatus.UnknownSigner ->
+            "UNKNOWN SIGNER — ${status.signerKeyId}" to MaterialTheme.colorScheme.onSurfaceVariant
+        SignatureStatus.None ->
+            "UNSIGNED" to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = color.copy(alpha = 0.12f),
+        border = BorderStroke(1.dp, color.copy(alpha = 0.3f)),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = CryptoFontFamily,
+            color = color,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            letterSpacing = 0.5.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+private fun resolveSignerKey(
+    status: SignatureStatus,
+    allKeys: List<PgpKey>,
+): PgpKey? = when (status) {
+    is SignatureStatus.Valid -> allKeys.firstOrNull { key ->
+        key.fingerprint.endsWith(status.signerFingerprint.takeLast(16), ignoreCase = true) ||
+            key.fingerprint.equals(status.signerFingerprint, ignoreCase = true)
+    }
+    else -> null
 }

--- a/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/decrypt/DecryptViewModel.kt
@@ -1,0 +1,157 @@
+package com.cezila.hermes.presentation.decrypt
+
+import androidx.lifecycle.viewModelScope
+import com.cezila.hermes.core.data.di.IoDispatcher
+import com.cezila.hermes.core.domain.usecase.DecryptAndVerifyUseCase
+import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
+import com.cezila.hermes.presentation.mvi.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DecryptViewModel @Inject constructor(
+    private val getAllKeysUseCase: GetAllKeysUseCase,
+    private val decryptAndVerifyUseCase: DecryptAndVerifyUseCase,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : BaseViewModel<DecryptUiState, DecryptUiEvent, DecryptUiEffect>(
+    initialState = DecryptUiState(),
+) {
+
+    init {
+        getAllKeysUseCase()
+            .onEach { keys ->
+                setState {
+                    copy(
+                        allKeys = keys,
+                        ownKey = keys.firstOrNull { it.isSecret },
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    override fun handleEvent(event: DecryptUiEvent) {
+        when (event) {
+            is DecryptUiEvent.OnCiphertextChanged ->
+                setState {
+                    copy(
+                        ciphertextInput = event.text,
+                        headerStatus = event.text.detectHeaderStatus(),
+                        error = null,
+                    )
+                }
+
+            DecryptUiEvent.OnPasteFromClipboard ->
+                sendEffect(DecryptUiEffect.RequestClipboardRead)
+
+            DecryptUiEvent.OnClearInput ->
+                setState {
+                    copy(
+                        ciphertextInput = "",
+                        headerStatus = HeaderStatus.Awaiting,
+                        error = null,
+                        decryptionResult = null,
+                    )
+                }
+
+            is DecryptUiEvent.OnFileSelected ->
+                setState {
+                    copy(
+                        selectedFileBytes = event.bytes,
+                        selectedFileName = event.name,
+                        inputMode = InputMode.FILE,
+                        error = null,
+                    )
+                }
+
+            DecryptUiEvent.OnClearFile ->
+                setState { copy(selectedFileBytes = null, selectedFileName = null) }
+
+            is DecryptUiEvent.OnInputModeChanged ->
+                setState { copy(inputMode = event.mode, error = null) }
+
+            DecryptUiEvent.OnDecryptClick -> onDecryptClick()
+
+            is DecryptUiEvent.OnPassphraseConfirmed -> onPassphraseConfirmed(event.passphrase)
+
+            DecryptUiEvent.OnPassphraseDismissed ->
+                setState { copy(showPassphraseDialog = false) }
+
+            DecryptUiEvent.OnCopyPlaintext ->
+                currentState.decryptionResult?.plaintext
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { sendEffect(DecryptUiEffect.CopyToClipboard(it)) }
+
+            DecryptUiEvent.OnSaveDecryptedFile -> {
+                val result = currentState.decryptionResult ?: return
+                val bytes = result.plaintextBytes ?: return
+                val name = result.fileName ?: "decrypted_file"
+                sendEffect(DecryptUiEffect.SaveDecryptedFile(bytes, name))
+            }
+
+            DecryptUiEvent.OnDismissResult ->
+                setState { copy(decryptionResult = null) }
+
+            DecryptUiEvent.OnDismissError ->
+                setState { copy(error = null) }
+        }
+    }
+
+    private fun onDecryptClick() {
+        if (currentState.ownKey == null) {
+            setState { copy(error = "No identity key found. Generate your key first.") }
+            return
+        }
+        setState { copy(showPassphraseDialog = true) }
+    }
+
+    private fun onPassphraseConfirmed(passphrase: CharArray) {
+        setState { copy(showPassphraseDialog = false) }
+        val state = currentState
+        val ownKey = state.ownKey ?: return
+
+        viewModelScope.launch(ioDispatcher) {
+            setState { copy(isLoading = true, error = null) }
+            try {
+                decryptAndVerifyUseCase(
+                    DecryptAndVerifyUseCase.Params(
+                        ciphertext = state.ciphertextInput,
+                        fileBytes = if (state.inputMode == InputMode.FILE) state.selectedFileBytes else null,
+                        recipientKeyId = ownKey.id,
+                        passphrase = passphrase,
+                    )
+                ).fold(
+                    onSuccess = { result -> setState { copy(decryptionResult = result) } },
+                    onFailure = { setState { copy(error = it.toUserMessage()) } },
+                )
+            } finally {
+                passphrase.fill(' ')
+                setState { copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun Throwable.toUserMessage(): String = when {
+        message?.contains("checksum", ignoreCase = true) == true ||
+            message?.contains("integrity", ignoreCase = true) == true ||
+            message?.contains("decryption failed", ignoreCase = true) == true ->
+            "Wrong passphrase or corrupted message."
+        message?.contains("no suitable", ignoreCase = true) == true ||
+            message?.contains("not encrypted for", ignoreCase = true) == true ->
+            "This message was not encrypted for your key."
+        message?.contains("armor", ignoreCase = true) == true ->
+            "Invalid PGP message format."
+        else -> "Decryption failed. Please try again."
+    }
+
+    private fun String.detectHeaderStatus(): HeaderStatus = when {
+        isBlank() -> HeaderStatus.Awaiting
+        contains("-----BEGIN PGP MESSAGE-----") -> HeaderStatus.Valid
+        else -> HeaderStatus.Invalid
+    }
+}

--- a/app/src/main/java/com/cezila/hermes/presentation/keygeneration/KeyGenerationViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keygeneration/KeyGenerationViewModel.kt
@@ -1,10 +1,11 @@
 package com.cezila.hermes.presentation.keygeneration
 
-import android.util.Patterns
 import androidx.lifecycle.viewModelScope
+import com.cezila.hermes.core.data.di.IoDispatcher
 import com.cezila.hermes.core.domain.usecase.GenerateKeyPairUseCase
 import com.cezila.hermes.presentation.mvi.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -12,6 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class KeyGenerationViewModel @Inject constructor(
     private val generateKeyPairUseCase: GenerateKeyPairUseCase,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseViewModel<KeyGenerationUiState, KeyGenerationUiEvent, KeyGenerationUiEffect>(
     initialState = KeyGenerationUiState(),
 ) {
@@ -43,7 +45,7 @@ class KeyGenerationViewModel @Inject constructor(
     private fun generate() {
         if (!validate()) return
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             setState { copy(isLoading = true, generalError = null) }
             val passphraseArray = currentState.passphrase.toCharArray()
             try {
@@ -66,6 +68,10 @@ class KeyGenerationViewModel @Inject constructor(
         }
     }
 
+    companion object {
+        private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$")
+    }
+
     private fun validate(): Boolean {
         val state = currentState
         var isValid = true
@@ -75,7 +81,7 @@ class KeyGenerationViewModel @Inject constructor(
             isValid = false
         }
 
-        if (!Patterns.EMAIL_ADDRESS.matcher(state.ownerEmail.trim()).matches()) {
+        if (!EMAIL_REGEX.matches(state.ownerEmail.trim())) {
             setState { copy(emailError = "Enter a valid email address") }
             isValid = false
         }

--- a/app/src/main/java/com/cezila/hermes/presentation/keyimport/KeyImportViewModel.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/keyimport/KeyImportViewModel.kt
@@ -2,10 +2,12 @@ package com.cezila.hermes.presentation.keyimport
 
 import android.database.sqlite.SQLiteConstraintException
 import androidx.lifecycle.viewModelScope
+import com.cezila.hermes.core.data.di.IoDispatcher
 import com.cezila.hermes.core.domain.crypto.PgpKeyParser
 import com.cezila.hermes.core.domain.usecase.ImportPublicKeyUseCase
 import com.cezila.hermes.presentation.mvi.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -15,6 +17,7 @@ import javax.inject.Inject
 class KeyImportViewModel @Inject constructor(
     private val importPublicKeyUseCase: ImportPublicKeyUseCase,
     private val pgpKeyParser: PgpKeyParser,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BaseViewModel<KeyImportUiState, KeyImportUiEvent, KeyImportUiEffect>(
     initialState = KeyImportUiState(),
 ) {
@@ -46,7 +49,7 @@ class KeyImportViewModel @Inject constructor(
             return
         }
         setState { copy(validationStatus = ValidationStatus.Validating) }
-        validationJob = viewModelScope.launch(Dispatchers.IO) {
+        validationJob = viewModelScope.launch(ioDispatcher) {
             if (text.contains("-----BEGIN PGP PRIVATE KEY BLOCK-----")) {
                 setState { copy(validationStatus = ValidationStatus.Invalid(ValidationError.SecretKeyDetected)) }
                 return@launch
@@ -60,7 +63,7 @@ class KeyImportViewModel @Inject constructor(
 
     private fun importKey() {
         if (currentState.validationStatus != ValidationStatus.Valid) return
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             setState { copy(isLoading = true) }
             try {
                 importPublicKeyUseCase(ImportPublicKeyUseCase.Params(currentState.armoredText))

--- a/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
+++ b/app/src/main/java/com/cezila/hermes/presentation/navigation/HermesNavHost.kt
@@ -22,6 +22,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.cezila.hermes.presentation.decrypt.DecryptScreen
+import com.cezila.hermes.presentation.decrypt.DecryptUiEffect
+import com.cezila.hermes.presentation.decrypt.DecryptUiEvent
+import com.cezila.hermes.presentation.decrypt.DecryptViewModel
 import com.cezila.hermes.presentation.encrypt.EncryptScreen
 import com.cezila.hermes.presentation.encrypt.EncryptUiEffect
 import com.cezila.hermes.presentation.encrypt.EncryptUiEvent
@@ -265,6 +268,83 @@ fun HermesNavHost(
                 onPickFile = { filePickerLauncher.launch(arrayOf("*/*")) },
             )
         }
-        composable<Route.Decrypt> { DecryptScreen() }
+        composable<Route.Decrypt> {
+            val viewModel: DecryptViewModel = hiltViewModel()
+            val state by viewModel.state.collectAsState()
+            val context = LocalContext.current
+            val scope = rememberCoroutineScope()
+
+            val filePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.OpenDocument(),
+            ) { uri ->
+                uri ?: return@rememberLauncherForActivityResult
+                scope.launch {
+                    val (bytes, name) = withContext(Dispatchers.IO) {
+                        val resolver = context.contentResolver
+                        var fileName = uri.lastPathSegment ?: "file"
+                        resolver.query(uri, null, null, null, null)?.use { cursor ->
+                            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            if (cursor.moveToFirst() && nameIndex >= 0) {
+                                fileName = cursor.getString(nameIndex)
+                            }
+                        }
+                        val fileBytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: byteArrayOf()
+                        Pair(fileBytes, fileName)
+                    }
+                    viewModel.onEvent(DecryptUiEvent.OnFileSelected(bytes, name))
+                }
+            }
+
+            val pendingDecryptedFile = remember { mutableStateOf<ByteArray?>(null) }
+
+            val saveFileLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.CreateDocument("application/octet-stream"),
+            ) { uri ->
+                uri ?: return@rememberLauncherForActivityResult
+                val bytes = pendingDecryptedFile.value ?: return@rememberLauncherForActivityResult
+                scope.launch(Dispatchers.IO) {
+                    context.contentResolver.openOutputStream(uri)?.use { it.write(bytes) }
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, "File saved", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                pendingDecryptedFile.value = null
+            }
+
+            LaunchedEffect(viewModel) {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        DecryptUiEffect.PickFile ->
+                            filePickerLauncher.launch(arrayOf("*/*"))
+
+                        is DecryptUiEffect.SaveDecryptedFile -> {
+                            pendingDecryptedFile.value = effect.bytes
+                            saveFileLauncher.launch(effect.suggestedName)
+                        }
+
+                        is DecryptUiEffect.CopyToClipboard -> {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            clipboard.setPrimaryClip(ClipData.newPlainText("Decrypted Message", effect.text))
+                            Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                        }
+
+                        is DecryptUiEffect.ShowToast ->
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+
+                        DecryptUiEffect.RequestClipboardRead -> {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            val text = clipboard.primaryClip?.getItemAt(0)?.text?.toString() ?: ""
+                            viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(text))
+                        }
+                    }
+                }
+            }
+
+            DecryptScreen(
+                state = state,
+                onEvent = viewModel::onEvent,
+                onPickFile = { filePickerLauncher.launch(arrayOf("*/*")) },
+            )
+        }
     }
 }

--- a/app/src/test/java/com/cezila/hermes/presentation/decrypt/DecryptViewModelTest.kt
+++ b/app/src/test/java/com/cezila/hermes/presentation/decrypt/DecryptViewModelTest.kt
@@ -1,0 +1,379 @@
+package com.cezila.hermes.presentation.decrypt
+
+import app.cash.turbine.test
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.model.SignatureStatus
+import com.cezila.hermes.core.domain.usecase.DecryptAndVerifyUseCase
+import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DecryptViewModelTest {
+
+    private val getAllKeysUseCase: GetAllKeysUseCase = mockk()
+    private val decryptAndVerifyUseCase: DecryptAndVerifyUseCase = mockk()
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: DecryptViewModel
+
+    private val ownKey = PgpKey(
+        id = "0xMYKEY",
+        fingerprint = "AABBCCDDEEFF0011",
+        ownerName = "Alice",
+        ownerEmail = "alice@example.com",
+        algorithm = KeyAlgorithm.ED25519,
+        createdAt = 1_700_000_000_000L,
+        expiresAt = null,
+        isSecret = true,
+        armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n-----END PGP PUBLIC KEY BLOCK-----",
+    )
+
+    private val contactKey = PgpKey(
+        id = "0xBOBKEY",
+        fingerprint = "1122334455667788",
+        ownerName = "Bob",
+        ownerEmail = "bob@example.com",
+        algorithm = KeyAlgorithm.RSA_4096,
+        createdAt = 1_700_000_000_000L,
+        expiresAt = null,
+        isSecret = false,
+        armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nBob\n-----END PGP PUBLIC KEY BLOCK-----",
+    )
+
+    private val successResult = DecryptionResult(
+        plaintext = "Hello, Alice!",
+        plaintextBytes = null,
+        fileName = null,
+        signatureStatus = SignatureStatus.None,
+    )
+
+    private val validCiphertext = "-----BEGIN PGP MESSAGE-----\nencrypted\n-----END PGP MESSAGE-----"
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        every { getAllKeysUseCase() } returns flowOf(listOf(ownKey, contactKey))
+        viewModel = DecryptViewModel(getAllKeysUseCase, decryptAndVerifyUseCase, testDispatcher)
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- init ---
+
+    @Test
+    fun init_setsOwnKeyFromSecretKey() {
+        assertEquals(ownKey, viewModel.state.value.ownKey)
+    }
+
+    @Test
+    fun init_setsAllKeysIncludingContacts() {
+        assertEquals(listOf(ownKey, contactKey), viewModel.state.value.allKeys)
+    }
+
+    @Test
+    fun init_withNoOwnKey_ownKeyIsNull() {
+        every { getAllKeysUseCase() } returns flowOf(listOf(contactKey))
+        val vm = DecryptViewModel(getAllKeysUseCase, decryptAndVerifyUseCase, testDispatcher)
+        assertNull(vm.state.value.ownKey)
+        assertEquals(listOf(contactKey), vm.state.value.allKeys)
+    }
+
+    // --- Header status ---
+
+    @Test
+    fun onCiphertextChanged_blankText_setsHeaderStatusAwaiting() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(""))
+        assertEquals(HeaderStatus.Awaiting, viewModel.state.value.headerStatus)
+    }
+
+    @Test
+    fun onCiphertextChanged_validPgpHeader_setsHeaderStatusValid() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        assertEquals(HeaderStatus.Valid, viewModel.state.value.headerStatus)
+    }
+
+    @Test
+    fun onCiphertextChanged_nonPgpContent_setsHeaderStatusInvalid() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged("just some random text"))
+        assertEquals(HeaderStatus.Invalid, viewModel.state.value.headerStatus)
+    }
+
+    @Test
+    fun onCiphertextChanged_updatesInputAndClearsError() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        assertEquals(validCiphertext, viewModel.state.value.ciphertextInput)
+        assertNull(viewModel.state.value.error)
+    }
+
+    // --- Clear ---
+
+    @Test
+    fun onClearInput_resetsAllTextInputState() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnClearInput)
+
+        assertEquals("", viewModel.state.value.ciphertextInput)
+        assertEquals(HeaderStatus.Awaiting, viewModel.state.value.headerStatus)
+        assertNull(viewModel.state.value.error)
+    }
+
+    // --- File ---
+
+    @Test
+    fun onFileSelected_setsFileBytesAndSwitchesToFileMode() {
+        val bytes = "data".toByteArray()
+        viewModel.onEvent(DecryptUiEvent.OnFileSelected(bytes, "doc.pgp"))
+
+        assertEquals(InputMode.FILE, viewModel.state.value.inputMode)
+        assertEquals("doc.pgp", viewModel.state.value.selectedFileName)
+        assertNotNull(viewModel.state.value.selectedFileBytes)
+    }
+
+    @Test
+    fun onClearFile_removesSelectedFile() {
+        viewModel.onEvent(DecryptUiEvent.OnFileSelected("data".toByteArray(), "doc.pgp"))
+        viewModel.onEvent(DecryptUiEvent.OnClearFile)
+
+        assertNull(viewModel.state.value.selectedFileBytes)
+        assertNull(viewModel.state.value.selectedFileName)
+    }
+
+    // --- Mode switch ---
+
+    @Test
+    fun onInputModeChanged_updatesMode() {
+        viewModel.onEvent(DecryptUiEvent.OnInputModeChanged(InputMode.FILE))
+        assertEquals(InputMode.FILE, viewModel.state.value.inputMode)
+    }
+
+    // --- canDecrypt ---
+
+    @Test
+    fun canDecrypt_textMode_validHeader_isTrue() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        assertTrue(viewModel.state.value.canDecrypt)
+    }
+
+    @Test
+    fun canDecrypt_textMode_awaitingHeader_isFalse() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(""))
+        assertFalse(viewModel.state.value.canDecrypt)
+    }
+
+    @Test
+    fun canDecrypt_fileMode_fileSelected_isTrue() {
+        viewModel.onEvent(DecryptUiEvent.OnFileSelected("data".toByteArray(), "doc.pgp"))
+        assertTrue(viewModel.state.value.canDecrypt)
+    }
+
+    @Test
+    fun canDecrypt_fileMode_noFileSelected_isFalse() {
+        viewModel.onEvent(DecryptUiEvent.OnInputModeChanged(InputMode.FILE))
+        assertFalse(viewModel.state.value.canDecrypt)
+    }
+
+    @Test
+    fun canDecrypt_noOwnKey_isFalse() {
+        every { getAllKeysUseCase() } returns flowOf(listOf(contactKey))
+        val vm = DecryptViewModel(getAllKeysUseCase, decryptAndVerifyUseCase, testDispatcher)
+        vm.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        assertFalse(vm.state.value.canDecrypt)
+    }
+
+    // --- Passphrase dialog ---
+
+    @Test
+    fun onDecryptClick_whenCanDecrypt_showsPassphraseDialog() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnDecryptClick)
+        assertTrue(viewModel.state.value.showPassphraseDialog)
+    }
+
+    @Test
+    fun onDecryptClick_whenNoOwnKey_setsErrorAndDoesNotShowDialog() {
+        every { getAllKeysUseCase() } returns flowOf(emptyList())
+        val vm = DecryptViewModel(getAllKeysUseCase, decryptAndVerifyUseCase, testDispatcher)
+        vm.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        vm.onEvent(DecryptUiEvent.OnDecryptClick)
+
+        assertFalse(vm.state.value.showPassphraseDialog)
+        assertNotNull(vm.state.value.error)
+    }
+
+    @Test
+    fun onPassphraseDismissed_hidesDialog() {
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnDecryptClick)
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseDismissed)
+        assertFalse(viewModel.state.value.showPassphraseDialog)
+    }
+
+    // --- Decrypt flow ---
+
+    @Test
+    fun onPassphraseConfirmed_success_setsDecryptionResult() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.success(successResult)
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        assertEquals(successResult, viewModel.state.value.decryptionResult)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun onPassphraseConfirmed_failure_setsError() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.failure(RuntimeException("checksum failed"))
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        assertNotNull(viewModel.state.value.error)
+        assertNull(viewModel.state.value.decryptionResult)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun onPassphraseConfirmed_alwaysWipesPassphrase() = runTest {
+        val paramsSlot = slot<DecryptAndVerifyUseCase.Params>()
+        coEvery { decryptAndVerifyUseCase(capture(paramsSlot)) } returns Result.success(successResult)
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("s3cr3t".toCharArray()))
+
+        assertTrue(paramsSlot.captured.passphrase.all { it == ' ' })
+    }
+
+    @Test
+    fun onPassphraseConfirmed_failure_alsoWipesPassphrase() = runTest {
+        val paramsSlot = slot<DecryptAndVerifyUseCase.Params>()
+        coEvery { decryptAndVerifyUseCase(capture(paramsSlot)) } returns Result.failure(RuntimeException("error"))
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("s3cr3t".toCharArray()))
+
+        assertTrue(paramsSlot.captured.passphrase.all { it == ' ' })
+    }
+
+    // --- Effects ---
+
+    @Test
+    fun onPasteFromClipboard_emitsRequestClipboardReadEffect() = runTest {
+        viewModel.effect.test {
+            viewModel.onEvent(DecryptUiEvent.OnPasteFromClipboard)
+            assertEquals(DecryptUiEffect.RequestClipboardRead, awaitItem())
+        }
+    }
+
+    @Test
+    fun onCopyPlaintext_withPlaintext_emitsCopyToClipboardEffect() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.success(successResult)
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        viewModel.effect.test {
+            viewModel.onEvent(DecryptUiEvent.OnCopyPlaintext)
+            val effect = awaitItem()
+            assertTrue(effect is DecryptUiEffect.CopyToClipboard)
+            assertEquals(successResult.plaintext, (effect as DecryptUiEffect.CopyToClipboard).text)
+        }
+    }
+
+    @Test
+    fun onSaveDecryptedFile_withFileResult_emitsSaveFileEffect() = runTest {
+        val fileBytes = "file content".toByteArray()
+        val fileResult = DecryptionResult(
+            plaintext = "",
+            plaintextBytes = fileBytes,
+            fileName = "doc.pdf",
+            signatureStatus = SignatureStatus.None,
+        )
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.success(fileResult)
+        viewModel.onEvent(DecryptUiEvent.OnFileSelected(fileBytes, "doc.pgp"))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        viewModel.effect.test {
+            viewModel.onEvent(DecryptUiEvent.OnSaveDecryptedFile)
+            val effect = awaitItem()
+            assertTrue(effect is DecryptUiEffect.SaveDecryptedFile)
+        }
+    }
+
+    // --- Dismiss ---
+
+    @Test
+    fun onDismissResult_clearsDecryptionResult() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.success(successResult)
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+        assertNotNull(viewModel.state.value.decryptionResult)
+
+        viewModel.onEvent(DecryptUiEvent.OnDismissResult)
+        assertNull(viewModel.state.value.decryptionResult)
+    }
+
+    @Test
+    fun onDismissError_clearsError() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.failure(RuntimeException("error"))
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+        assertNotNull(viewModel.state.value.error)
+
+        viewModel.onEvent(DecryptUiEvent.OnDismissError)
+        assertNull(viewModel.state.value.error)
+    }
+
+    // --- Error message mapping ---
+
+    @Test
+    fun decryptionError_checksumMessage_mapsToWrongPassphraseMessage() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.failure(RuntimeException("checksum failed"))
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        assertTrue(viewModel.state.value.error!!.contains("passphrase", ignoreCase = true))
+    }
+
+    @Test
+    fun decryptionError_noSuitableKey_mapsToNotEncryptedForYouMessage() = runTest {
+        coEvery { decryptAndVerifyUseCase(any()) } returns Result.failure(RuntimeException("no suitable key"))
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        assertTrue(viewModel.state.value.error!!.contains("key", ignoreCase = true))
+    }
+
+    @Test
+    fun decryptionError_verifyUseCaseIsCalledWithOwnKeyId() = runTest {
+        val paramsSlot = slot<DecryptAndVerifyUseCase.Params>()
+        coEvery { decryptAndVerifyUseCase(capture(paramsSlot)) } returns Result.success(successResult)
+        viewModel.onEvent(DecryptUiEvent.OnCiphertextChanged(validCiphertext))
+        viewModel.onEvent(DecryptUiEvent.OnPassphraseConfirmed("pass".toCharArray()))
+
+        assertEquals(ownKey.id, paramsSlot.captured.recipientKeyId)
+        coVerify(exactly = 1) { decryptAndVerifyUseCase(any()) }
+    }
+}

--- a/app/src/test/java/com/cezila/hermes/presentation/keygeneration/KeyGenerationViewModelTest.kt
+++ b/app/src/test/java/com/cezila/hermes/presentation/keygeneration/KeyGenerationViewModelTest.kt
@@ -1,21 +1,16 @@
 package com.cezila.hermes.presentation.keygeneration
 
-import android.util.Patterns
 import app.cash.turbine.test
 import com.cezila.hermes.core.domain.model.KeyAlgorithm
 import com.cezila.hermes.core.domain.model.PgpKey
 import com.cezila.hermes.core.domain.usecase.GenerateKeyPairUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -27,8 +22,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class KeyGenerationViewModelTest {
@@ -36,9 +29,6 @@ class KeyGenerationViewModelTest {
     private val generateKeyPairUseCase: GenerateKeyPairUseCase = mockk()
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var viewModel: KeyGenerationViewModel
-
-    private val mockEmailPattern: Pattern = mockk()
-    private val mockMatcher: Matcher = mockk()
 
     private val fakePgpKey = PgpKey(
         id = "0xAABB",
@@ -55,16 +45,11 @@ class KeyGenerationViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        mockkStatic(Patterns::class)
-        every { Patterns.EMAIL_ADDRESS } returns mockEmailPattern
-        every { mockEmailPattern.matcher(any()) } returns mockMatcher
-        every { mockMatcher.matches() } returns true
-        viewModel = KeyGenerationViewModel(generateKeyPairUseCase)
+        viewModel = KeyGenerationViewModel(generateKeyPairUseCase, testDispatcher)
     }
 
     @After
     fun teardown() {
-        unmockkStatic(Patterns::class)
         Dispatchers.resetMain()
     }
 
@@ -91,12 +76,11 @@ class KeyGenerationViewModelTest {
 
     @Test
     fun onEmailChange_updatesStateAndClearsEmailError() {
-        every { mockMatcher.matches() } returns false
         viewModel.onEvent(KeyGenerationUiEvent.OnNameChange("Alice"))
+        viewModel.onEvent(KeyGenerationUiEvent.OnEmailChange("not-an-email"))
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
         assertNotNull(viewModel.state.value.emailError)
 
-        every { mockMatcher.matches() } returns true
         viewModel.onEvent(KeyGenerationUiEvent.OnEmailChange("alice@example.com"))
 
         assertEquals("alice@example.com", viewModel.state.value.ownerEmail)
@@ -158,8 +142,8 @@ class KeyGenerationViewModelTest {
 
     @Test
     fun validate_invalidEmail_setsEmailError() {
-        every { mockMatcher.matches() } returns false
         viewModel.onEvent(KeyGenerationUiEvent.OnNameChange("Alice"))
+        viewModel.onEvent(KeyGenerationUiEvent.OnEmailChange("not-an-email"))
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
 
         assertNotNull(viewModel.state.value.emailError)
@@ -187,8 +171,8 @@ class KeyGenerationViewModelTest {
 
     @Test
     fun validate_multipleErrors_setsAllErrors() {
-        every { mockMatcher.matches() } returns false
         viewModel.onEvent(KeyGenerationUiEvent.OnNameChange("   "))
+        viewModel.onEvent(KeyGenerationUiEvent.OnEmailChange("not-an-email"))
         viewModel.onEvent(KeyGenerationUiEvent.OnPassphraseChange("short"))
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
 
@@ -214,7 +198,6 @@ class KeyGenerationViewModelTest {
 
         viewModel.effect.test {
             viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-            advanceUntilIdle()
             assertEquals(KeyGenerationUiEffect.NavigateToKeys, awaitItem())
         }
     }
@@ -225,7 +208,6 @@ class KeyGenerationViewModelTest {
         setValidState()
 
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-        advanceUntilIdle()
 
         assertFalse(viewModel.state.value.isLoading)
     }
@@ -236,7 +218,6 @@ class KeyGenerationViewModelTest {
         setValidState()
 
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-        advanceUntilIdle()
 
         assertEquals("generation failed", viewModel.state.value.generalError)
         assertFalse(viewModel.state.value.isLoading)
@@ -248,7 +229,6 @@ class KeyGenerationViewModelTest {
         setValidState()
 
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-        advanceUntilIdle()
 
         assertEquals("Key generation failed", viewModel.state.value.generalError)
     }
@@ -260,7 +240,6 @@ class KeyGenerationViewModelTest {
         setValidState()
 
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-        advanceUntilIdle()
 
         assertTrue(paramsSlot.captured.passphrase.all { it == ' ' })
     }
@@ -275,7 +254,6 @@ class KeyGenerationViewModelTest {
         viewModel.onEvent(KeyGenerationUiEvent.OnPassphraseChange("correct-horse"))
         viewModel.onEvent(KeyGenerationUiEvent.OnConfirmPassphraseChange("correct-horse"))
         viewModel.onEvent(KeyGenerationUiEvent.OnGenerateClick)
-        advanceUntilIdle()
 
         assertEquals("Alice", paramsSlot.captured.ownerName)
         assertEquals("alice@example.com", paramsSlot.captured.ownerEmail)

--- a/app/src/test/java/com/cezila/hermes/presentation/keyimport/KeyImportViewModelTest.kt
+++ b/app/src/test/java/com/cezila/hermes/presentation/keyimport/KeyImportViewModelTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -55,7 +54,7 @@ class KeyImportViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = KeyImportViewModel(importPublicKeyUseCase, pgpKeyParser)
+        viewModel = KeyImportViewModel(importPublicKeyUseCase, pgpKeyParser, testDispatcher)
     }
 
     @After
@@ -68,7 +67,6 @@ class KeyImportViewModelTest {
     @Test
     fun emptyText_keepsEmptyStatus() = runTest {
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(""))
-        advanceUntilIdle()
 
         assertEquals(ValidationStatus.Empty, viewModel.state.value.validationStatus)
     }
@@ -76,7 +74,6 @@ class KeyImportViewModelTest {
     @Test
     fun blankText_keepsEmptyStatus() = runTest {
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange("   "))
-        advanceUntilIdle()
 
         assertEquals(ValidationStatus.Empty, viewModel.state.value.validationStatus)
     }
@@ -84,7 +81,6 @@ class KeyImportViewModelTest {
     @Test
     fun secretKeyBlock_setsSecretKeyDetected() = runTest {
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(SECRET_KEY_BLOCK))
-        advanceUntilIdle()
 
         assertEquals(
             ValidationStatus.Invalid(ValidationError.SecretKeyDetected),
@@ -98,7 +94,6 @@ class KeyImportViewModelTest {
         coEvery { pgpKeyParser.parsePublicKey(any()) } returns Result.failure(IllegalArgumentException("bad key"))
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange("not a pgp key"))
-        advanceUntilIdle()
 
         assertEquals(
             ValidationStatus.Invalid(ValidationError.InvalidFormat),
@@ -111,7 +106,6 @@ class KeyImportViewModelTest {
         coEvery { pgpKeyParser.parsePublicKey(any()) } returns Result.success(fakeParsedKey)
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(VALID_ARMORED_KEY))
-        advanceUntilIdle()
 
         assertEquals(ValidationStatus.Valid, viewModel.state.value.validationStatus)
     }
@@ -123,7 +117,6 @@ class KeyImportViewModelTest {
         coEvery { pgpKeyParser.parsePublicKey(any()) } returns Result.success(fakeParsedKey)
 
         viewModel.onEvent(KeyImportUiEvent.OnFileRead(VALID_ARMORED_KEY, "alice.asc"))
-        advanceUntilIdle()
 
         assertEquals(VALID_ARMORED_KEY, viewModel.state.value.armoredText)
         assertEquals("alice.asc", viewModel.state.value.fileName)
@@ -136,7 +129,6 @@ class KeyImportViewModelTest {
 
         viewModel.onEvent(KeyImportUiEvent.OnFileRead(VALID_ARMORED_KEY, "alice.asc"))
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange("different text"))
-        advanceUntilIdle()
 
         assertEquals(null, viewModel.state.value.fileName)
     }
@@ -146,7 +138,6 @@ class KeyImportViewModelTest {
     @Test
     fun importClick_whenNotValid_doesNotCallUseCase() = runTest {
         viewModel.onEvent(KeyImportUiEvent.OnImportClick)
-        advanceUntilIdle()
 
         coVerify(exactly = 0) { importPublicKeyUseCase(any()) }
     }
@@ -157,11 +148,9 @@ class KeyImportViewModelTest {
         coEvery { importPublicKeyUseCase(any()) } returns Result.success(fakePgpKey)
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(VALID_ARMORED_KEY))
-        advanceUntilIdle()
 
         viewModel.effect.test {
             viewModel.onEvent(KeyImportUiEvent.OnImportClick)
-            advanceUntilIdle()
             assertEquals(KeyImportUiEffect.ImportSuccess, awaitItem())
         }
     }
@@ -172,9 +161,7 @@ class KeyImportViewModelTest {
         coEvery { importPublicKeyUseCase(any()) } returns Result.success(fakePgpKey)
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(VALID_ARMORED_KEY))
-        advanceUntilIdle()
         viewModel.onEvent(KeyImportUiEvent.OnImportClick)
-        advanceUntilIdle()
 
         assertFalse(viewModel.state.value.isLoading)
     }
@@ -185,9 +172,7 @@ class KeyImportViewModelTest {
         coEvery { importPublicKeyUseCase(any()) } returns Result.failure(android.database.sqlite.SQLiteConstraintException("UNIQUE constraint failed"))
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(VALID_ARMORED_KEY))
-        advanceUntilIdle()
         viewModel.onEvent(KeyImportUiEvent.OnImportClick)
-        advanceUntilIdle()
 
         assertEquals(
             ValidationStatus.Invalid(ValidationError.DuplicateKey),
@@ -201,9 +186,7 @@ class KeyImportViewModelTest {
         coEvery { importPublicKeyUseCase(any()) } returns Result.failure(RuntimeException("unexpected"))
 
         viewModel.onEvent(KeyImportUiEvent.OnArmoredTextChange(VALID_ARMORED_KEY))
-        advanceUntilIdle()
         viewModel.onEvent(KeyImportUiEvent.OnImportClick)
-        advanceUntilIdle()
 
         assertEquals(
             ValidationStatus.Invalid(ValidationError.InvalidFormat),

--- a/app/src/test/java/com/cezila/hermes/presentation/keys/KeysViewModelTest.kt
+++ b/app/src/test/java/com/cezila/hermes/presentation/keys/KeysViewModelTest.kt
@@ -41,7 +41,7 @@ class KeysViewModelTest {
         armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----",
     )
 
-    private val fakeKey2 = fakeKey1.copy(id = "0xCCDD", fingerprint = "CCDD")
+    private val fakeKey2 = fakeKey1.copy(id = "0xCCDD", fingerprint = "CCDD", isSecret = false)
 
     @Before
     fun setup() {
@@ -60,7 +60,7 @@ class KeysViewModelTest {
         advanceUntilIdle()
 
         assertFalse(viewModel.state.value.isLoading)
-        assertTrue(viewModel.state.value.keys.isEmpty())
+        assertFalse(viewModel.state.value.hasKeys)
     }
 
     @Test
@@ -69,8 +69,8 @@ class KeysViewModelTest {
         val viewModel = KeysViewModel(getAllKeysUseCase)
         advanceUntilIdle()
 
-        assertEquals(2, viewModel.state.value.keys.size)
-        assertEquals(fakeKey1, viewModel.state.value.keys[0])
+        assertEquals(fakeKey1, viewModel.state.value.ownKey)
+        assertEquals(1, viewModel.state.value.contacts.size)
     }
 
     @Test
@@ -83,7 +83,7 @@ class KeysViewModelTest {
         val viewModel = KeysViewModel(getAllKeysUseCase)
 
         advanceUntilIdle()
-        assertEquals(2, viewModel.state.value.keys.size)
+        assertTrue(viewModel.state.value.hasKeys)
     }
 
     @Test
@@ -110,7 +110,7 @@ class KeysViewModelTest {
         advanceUntilIdle()
 
         viewModel.effect.test {
-            viewModel.onEvent(KeysUiEvent.OnAddKeyClick)
+            viewModel.onEvent(KeysUiEvent.OnGenerateKeyClick)
             assertEquals(KeysUiEffect.NavigateToKeyGeneration, awaitItem())
         }
     }

--- a/app/src/test/java/com/cezila/hermes/presentation/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/cezila/hermes/presentation/onboarding/OnboardingViewModelTest.kt
@@ -1,8 +1,12 @@
 package com.cezila.hermes.presentation.onboarding
 
 import app.cash.turbine.test
+import com.cezila.hermes.core.domain.usecase.GetAllKeysUseCase
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -16,13 +20,15 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class OnboardingViewModelTest {
 
+    private val getAllKeysUseCase: GetAllKeysUseCase = mockk()
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var viewModel: OnboardingViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = OnboardingViewModel()
+        every { getAllKeysUseCase() } returns flowOf(emptyList())
+        viewModel = OnboardingViewModel(getAllKeysUseCase)
     }
 
     @After

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptor.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptor.kt
@@ -1,0 +1,215 @@
+package com.cezila.hermes.core.data.crypto
+
+import com.cezila.hermes.core.domain.crypto.PgpDecryptor
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.model.SignatureStatus
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openpgp.PGPCompressedData
+import org.bouncycastle.openpgp.PGPEncryptedDataList
+import org.bouncycastle.openpgp.PGPLiteralData
+import org.bouncycastle.openpgp.PGPOnePassSignature
+import org.bouncycastle.openpgp.PGPOnePassSignatureList
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.bouncycastle.openpgp.PGPPublicKeyEncryptedData
+import org.bouncycastle.openpgp.PGPPublicKeyRing
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+import org.bouncycastle.openpgp.PGPSecretKey
+import org.bouncycastle.openpgp.PGPSecretKeyRing
+import org.bouncycastle.openpgp.PGPSignatureList
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentVerifierBuilderProvider
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder
+import org.bouncycastle.openpgp.operator.jcajce.JcePublicKeyDataDecryptorFactoryBuilder
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+class BouncyCastlePgpDecryptor : PgpDecryptor {
+
+    private val provider = BouncyCastleProvider()
+
+    override suspend fun decryptAndVerify(
+        ciphertext: String,
+        recipientArmoredPrivateKey: String,
+        passphrase: CharArray,
+        knownPublicKeys: List<String>,
+    ): Result<DecryptionResult> = runCatching {
+        val stream = PGPUtil.getDecoderStream(ciphertext.byteInputStream(Charsets.UTF_8))
+        val keyRing = parseKeyRing(recipientArmoredPrivateKey)
+        decryptInternal(stream, keyRing, passphrase, knownPublicKeys, isFile = false)
+    }
+
+    override suspend fun decryptFileAndVerify(
+        ciphertextBytes: ByteArray,
+        recipientArmoredPrivateKey: String,
+        passphrase: CharArray,
+        knownPublicKeys: List<String>,
+    ): Result<DecryptionResult> = runCatching {
+        val stream = PGPUtil.getDecoderStream(ByteArrayInputStream(ciphertextBytes))
+        val keyRing = parseKeyRing(recipientArmoredPrivateKey)
+        decryptInternal(stream, keyRing, passphrase, knownPublicKeys, isFile = true)
+    }
+
+    private fun decryptInternal(
+        encryptedStream: InputStream,
+        keyRing: PGPSecretKeyRing,
+        passphrase: CharArray,
+        knownPublicKeys: List<String>,
+        isFile: Boolean,
+    ): DecryptionResult {
+        val factory = JcaPGPObjectFactory(encryptedStream)
+
+        // Unwrap encrypted layer
+        val encDataList = when (val first = factory.nextObject()) {
+            is PGPEncryptedDataList -> first
+            else -> factory.nextObject() as? PGPEncryptedDataList
+                ?: throw IllegalArgumentException("No encrypted data found in message")
+        }
+
+        // Find a PKESK whose keyID matches any key in our ring (master or subkey)
+        val pkesks = encDataList.encryptedDataObjects.asSequence()
+            .filterIsInstance<PGPPublicKeyEncryptedData>()
+            .toList()
+
+        val (matchedSecretKey, pkesk) = run {
+            for (candidate in pkesks) {
+                val sk = keyRing.secretKeys.asSequence()
+                    .firstOrNull { it.keyID == candidate.keyID }
+                if (sk != null) return@run Pair(sk, candidate)
+            }
+            throw IllegalArgumentException("Message not encrypted for this key")
+        }
+
+        val decryptor = JcePBESecretKeyDecryptorBuilder().setProvider(provider).build(passphrase)
+        val privateKey = matchedSecretKey.extractPrivateKey(decryptor)
+
+        val decryptedStream = pkesk.getDataStream(
+            JcePublicKeyDataDecryptorFactoryBuilder().setProvider(provider).build(privateKey)
+        )
+
+        // Parse inner objects
+        var innerFactory = JcaPGPObjectFactory(decryptedStream)
+        var obj = innerFactory.nextObject()
+
+        // Unwrap compression if present
+        if (obj is PGPCompressedData) {
+            innerFactory = JcaPGPObjectFactory(obj.dataStream)
+            obj = innerFactory.nextObject()
+        }
+
+        // OnePassSignature: look up signer key immediately so we can init before reading literal data
+        var ops: PGPOnePassSignature? = null
+        var signerPublicKey: PGPPublicKey? = null
+        var signerKeyId: Long = 0L
+        var opsInitialized = false
+
+        if (obj is PGPOnePassSignatureList) {
+            ops = obj.get(0)
+            signerKeyId = ops.keyID
+            signerPublicKey = findPublicKey(signerKeyId, knownPublicKeys)
+            if (signerPublicKey != null) {
+                ops.init(
+                    JcaPGPContentVerifierBuilderProvider().setProvider(provider),
+                    signerPublicKey,
+                )
+                opsInitialized = true
+            }
+            obj = innerFactory.nextObject()
+        }
+
+        // Read literal data
+        val literalData = obj as? PGPLiteralData
+            ?: throw IllegalArgumentException("No literal data found in message")
+
+        val fileName = literalData.fileName
+        val plainBytes = ByteArrayOutputStream().also { out ->
+            val buffer = ByteArray(8192)
+            val inputStream = literalData.inputStream
+            var bytesRead: Int
+            while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                out.write(buffer, 0, bytesRead)
+                if (opsInitialized) ops?.update(buffer, 0, bytesRead)
+            }
+        }.toByteArray()
+
+        // Signature list
+        val sigList = innerFactory.nextObject() as? PGPSignatureList
+
+        val signatureStatus = buildSignatureStatus(
+            ops = ops,
+            sigList = sigList,
+            signerKeyId = signerKeyId,
+            signerPublicKey = signerPublicKey,
+            opsInitialized = opsInitialized,
+        )
+
+        return if (isFile) {
+            DecryptionResult(
+                plaintext = "",
+                plaintextBytes = plainBytes,
+                fileName = fileName.takeIf { it.isNotBlank() },
+                signatureStatus = signatureStatus,
+            )
+        } else {
+            DecryptionResult(
+                plaintext = plainBytes.toString(Charsets.UTF_8),
+                plaintextBytes = null,
+                fileName = null,
+                signatureStatus = signatureStatus,
+            )
+        }
+    }
+
+    private fun buildSignatureStatus(
+        ops: PGPOnePassSignature?,
+        sigList: PGPSignatureList?,
+        signerKeyId: Long,
+        signerPublicKey: PGPPublicKey?,
+        opsInitialized: Boolean,
+    ): SignatureStatus {
+        if (ops == null || sigList == null || sigList.isEmpty) return SignatureStatus.None
+
+        val hexKeyId = signerKeyId.toHexKeyId()
+
+        if (!opsInitialized || signerPublicKey == null) {
+            return SignatureStatus.UnknownSigner(hexKeyId)
+        }
+
+        return runCatching {
+            val sig = sigList.get(0)
+            if (ops.verify(sig)) {
+                val fingerprint = signerPublicKey.fingerprint.joinToString("") { "%02X".format(it) }
+                SignatureStatus.Valid(signerKeyId = hexKeyId, signerFingerprint = fingerprint)
+            } else {
+                SignatureStatus.Invalid(signerKeyId = hexKeyId, reason = "Signature does not match")
+            }
+        }.getOrElse { e ->
+            SignatureStatus.Invalid(signerKeyId = hexKeyId, reason = e.message ?: "Verification failed")
+        }
+    }
+
+    private fun findPublicKey(keyId: Long, knownPublicKeys: List<String>): PGPPublicKey? =
+        knownPublicKeys.firstNotNullOfOrNull { armored ->
+            runCatching {
+                parsePublicKeyRing(armored).publicKeys.asSequence()
+                    .firstOrNull { it.keyID == keyId }
+            }.getOrNull()
+        }
+
+    private fun parseKeyRing(armored: String): PGPSecretKeyRing {
+        val stream = PGPUtil.getDecoderStream(armored.byteInputStream(Charsets.UTF_8))
+        return PGPSecretKeyRing(stream, JcaKeyFingerprintCalculator())
+    }
+
+    private fun parsePublicKeyRing(armored: String): PGPPublicKeyRing {
+        val stream = PGPUtil.getDecoderStream(armored.byteInputStream(Charsets.UTF_8))
+        val collection = PGPPublicKeyRingCollection(stream, JcaKeyFingerprintCalculator())
+        return collection.keyRings.asSequence().firstOrNull()
+            ?: throw IllegalArgumentException("No public key ring found")
+    }
+
+    private fun Long.toHexKeyId(): String =
+        "0x" + toULong().toString(16).uppercase().padStart(16, '0')
+}

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/CryptoModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/CryptoModule.kt
@@ -1,9 +1,11 @@
 package com.cezila.hermes.core.data.di
 
+import com.cezila.hermes.core.data.crypto.BouncyCastlePgpDecryptor
 import com.cezila.hermes.core.data.crypto.BouncyCastlePgpEncryptor
 import com.cezila.hermes.core.data.crypto.BouncyCastlePgpKeyGenerator
 import com.cezila.hermes.core.data.crypto.BouncyCastlePgpKeyParser
 import com.cezila.hermes.core.data.keystore.KeystoreManager
+import com.cezila.hermes.core.domain.crypto.PgpDecryptor
 import com.cezila.hermes.core.domain.crypto.PgpEncryptor
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
 import com.cezila.hermes.core.domain.crypto.PgpKeyParser
@@ -32,4 +34,8 @@ object CryptoModule {
     @Provides
     @Singleton
     fun providePgpEncryptor(): PgpEncryptor = BouncyCastlePgpEncryptor()
+
+    @Provides
+    @Singleton
+    fun providePgpDecryptor(): PgpDecryptor = BouncyCastlePgpDecryptor()
 }

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/di/UseCaseModule.kt
@@ -1,9 +1,11 @@
 package com.cezila.hermes.core.data.di
 
+import com.cezila.hermes.core.domain.crypto.PgpDecryptor
 import com.cezila.hermes.core.domain.crypto.PgpEncryptor
 import com.cezila.hermes.core.domain.crypto.PgpKeyGenerator
 import com.cezila.hermes.core.domain.crypto.PgpKeyParser
 import com.cezila.hermes.core.domain.repository.KeyRepository
+import com.cezila.hermes.core.domain.usecase.DecryptAndVerifyUseCase
 import com.cezila.hermes.core.domain.usecase.DeleteKeyUseCase
 import com.cezila.hermes.core.domain.usecase.EncryptAndSignUseCase
 import com.cezila.hermes.core.domain.usecase.EncryptFileAndSignUseCase
@@ -55,4 +57,10 @@ object UseCaseModule {
         keyRepository: KeyRepository,
         pgpEncryptor: PgpEncryptor,
     ): EncryptFileAndSignUseCase = EncryptFileAndSignUseCase(keyRepository, pgpEncryptor)
+
+    @Provides
+    fun provideDecryptAndVerifyUseCase(
+        keyRepository: KeyRepository,
+        pgpDecryptor: PgpDecryptor,
+    ): DecryptAndVerifyUseCase = DecryptAndVerifyUseCase(keyRepository, pgpDecryptor)
 }

--- a/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptorTest.kt
+++ b/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptorTest.kt
@@ -1,0 +1,233 @@
+package com.cezila.hermes.core.data.crypto
+
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import com.cezila.hermes.core.domain.model.SignatureStatus
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BouncyCastlePgpDecryptorTest {
+
+    private val generator = BouncyCastlePgpKeyGenerator()
+    private val encryptor = BouncyCastlePgpEncryptor()
+    private val decryptor = BouncyCastlePgpDecryptor()
+
+    private val passphrase = "test-passphrase-123".toCharArray()
+    private val plaintext = "Hello, this is a secret message!"
+
+    // RSA_4096 is used because the single-key ring it produces has isEncryptionKey=true,
+    // which is required by BouncyCastlePgpEncryptor.parseRecipientPublicKey.
+    // (Ed25519/EdDSA keys return isEncryptionKey=false regardless of key flags.)
+    private suspend fun generateKeyMaterial(name: String, email: String) =
+        generator.generate(name, email, KeyAlgorithm.RSA_4096, passphrase).getOrThrow()
+
+    // --- Round-trip: text ---
+
+    @Test
+    fun decryptAndVerify_roundTrip_returnsOriginalPlaintext() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+
+        assertEquals(plaintext, result.plaintext)
+        assertNull(result.plaintextBytes)
+        assertNull(result.fileName)
+    }
+
+    @Test
+    fun decryptAndVerify_signerInKnownKeys_returnsValidStatus() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+
+        assertTrue(result.signatureStatus is SignatureStatus.Valid)
+    }
+
+    @Test
+    fun decryptAndVerify_signerNotInKnownKeys_returnsUnknownSigner() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = emptyList(),
+        ).getOrThrow()
+
+        assertTrue(result.signatureStatus is SignatureStatus.UnknownSigner)
+    }
+
+    @Test
+    fun decryptAndVerify_wrongPassphrase_returnsFailure() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = "wrongpassword".toCharArray(),
+            knownPublicKeys = emptyList(),
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun decryptAndVerify_corruptedCiphertext_returnsFailure() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = "not a pgp message",
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = emptyList(),
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun decryptAndVerify_messageEncryptedForOtherKey_returnsFailure() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+        val carol = generateKeyMaterial("Carol", "carol@example.com")
+
+        // Encrypt for Bob, try to decrypt with Alice
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = bob.armoredPublicKey,
+            signerArmoredPrivateKey = carol.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = emptyList(),
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    // --- Round-trip: file ---
+
+    @Test
+    fun decryptFileAndVerify_roundTrip_returnsOriginalBytes() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+        val fileBytes = "file content goes here".toByteArray()
+        val fileName = "document.txt"
+
+        val encrypted = encryptor.encryptFileAndSign(
+            bytes = fileBytes,
+            fileName = fileName,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptFileAndVerify(
+            ciphertextBytes = encrypted,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+
+        assertNotNull(result.plaintextBytes)
+        assertTrue(result.plaintextBytes!!.contentEquals(fileBytes))
+        assertEquals(fileName, result.fileName)
+        assertTrue(result.plaintext.isEmpty())
+    }
+
+    @Test
+    fun decryptFileAndVerify_signerInKnownKeys_returnsValidStatus() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+        val fileBytes = "binary data".toByteArray()
+
+        val encrypted = encryptor.encryptFileAndSign(
+            bytes = fileBytes,
+            fileName = "data.bin",
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptFileAndVerify(
+            ciphertextBytes = encrypted,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+
+        assertTrue(result.signatureStatus is SignatureStatus.Valid)
+    }
+
+    @Test
+    fun decryptFileAndVerify_wrongPassphrase_returnsFailure() = runTest {
+        val alice = generateKeyMaterial("Alice", "alice@example.com")
+        val bob = generateKeyMaterial("Bob", "bob@example.com")
+
+        val encrypted = encryptor.encryptFileAndSign(
+            bytes = "data".toByteArray(),
+            fileName = "file.bin",
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+
+        val result = decryptor.decryptFileAndVerify(
+            ciphertextBytes = encrypted,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = "wrongpassword".toCharArray(),
+            knownPublicKeys = emptyList(),
+        )
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/crypto/PgpDecryptor.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/crypto/PgpDecryptor.kt
@@ -1,0 +1,19 @@
+package com.cezila.hermes.core.domain.crypto
+
+import com.cezila.hermes.core.domain.model.DecryptionResult
+
+interface PgpDecryptor {
+    suspend fun decryptAndVerify(
+        ciphertext: String,
+        recipientArmoredPrivateKey: String,
+        passphrase: CharArray,
+        knownPublicKeys: List<String>,
+    ): Result<DecryptionResult>
+
+    suspend fun decryptFileAndVerify(
+        ciphertextBytes: ByteArray,
+        recipientArmoredPrivateKey: String,
+        passphrase: CharArray,
+        knownPublicKeys: List<String>,
+    ): Result<DecryptionResult>
+}

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/model/DecryptionResult.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/model/DecryptionResult.kt
@@ -1,0 +1,47 @@
+package com.cezila.hermes.core.domain.model
+
+data class DecryptionResult(
+    val plaintext: String,
+    val plaintextBytes: ByteArray?,
+    val fileName: String?,
+    val signatureStatus: SignatureStatus,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DecryptionResult) return false
+        return plaintext == other.plaintext &&
+            plaintextBytes.contentEquals(other.plaintextBytes) &&
+            fileName == other.fileName &&
+            signatureStatus == other.signatureStatus
+    }
+
+    override fun hashCode(): Int {
+        var result = plaintext.hashCode()
+        result = 31 * result + (plaintextBytes?.contentHashCode() ?: 0)
+        result = 31 * result + (fileName?.hashCode() ?: 0)
+        result = 31 * result + signatureStatus.hashCode()
+        return result
+    }
+}
+
+private fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    if (this == null && other == null) return true
+    if (this == null || other == null) return false
+    return this.contentEquals(other)
+}
+
+sealed interface SignatureStatus {
+    data object None : SignatureStatus
+
+    data class Valid(
+        val signerKeyId: String,
+        val signerFingerprint: String,
+    ) : SignatureStatus
+
+    data class Invalid(
+        val signerKeyId: String,
+        val reason: String,
+    ) : SignatureStatus
+
+    data class UnknownSigner(val signerKeyId: String) : SignatureStatus
+}

--- a/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/DecryptAndVerifyUseCase.kt
+++ b/core/domain/src/main/kotlin/com/cezila/hermes/core/domain/usecase/DecryptAndVerifyUseCase.kt
@@ -1,0 +1,42 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.crypto.PgpDecryptor
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.repository.KeyRepository
+import kotlinx.coroutines.flow.first
+
+class DecryptAndVerifyUseCase(
+    private val keyRepository: KeyRepository,
+    private val pgpDecryptor: PgpDecryptor,
+) {
+    data class Params(
+        val ciphertext: String,
+        val fileBytes: ByteArray?,
+        val recipientKeyId: String,
+        val passphrase: CharArray,
+    )
+
+    suspend operator fun invoke(params: Params): Result<DecryptionResult> {
+        val armoredPrivateKey = keyRepository.getArmoredPrivateKey(params.recipientKeyId)
+            .getOrElse { return Result.failure(it) }
+
+        val allKeys = keyRepository.getAllKeys().first()
+        val knownPublicKeys = allKeys.map { it.armoredPublicKey }
+
+        return if (params.fileBytes != null) {
+            pgpDecryptor.decryptFileAndVerify(
+                ciphertextBytes = params.fileBytes,
+                recipientArmoredPrivateKey = armoredPrivateKey,
+                passphrase = params.passphrase,
+                knownPublicKeys = knownPublicKeys,
+            )
+        } else {
+            pgpDecryptor.decryptAndVerify(
+                ciphertext = params.ciphertext,
+                recipientArmoredPrivateKey = armoredPrivateKey,
+                passphrase = params.passphrase,
+                knownPublicKeys = knownPublicKeys,
+            )
+        }
+    }
+}

--- a/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/DecryptAndVerifyUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/cezila/hermes/core/domain/usecase/DecryptAndVerifyUseCaseTest.kt
@@ -1,0 +1,193 @@
+package com.cezila.hermes.core.domain.usecase
+
+import com.cezila.hermes.core.domain.crypto.PgpDecryptor
+import com.cezila.hermes.core.domain.model.DecryptionResult
+import com.cezila.hermes.core.domain.model.KeyAlgorithm
+import com.cezila.hermes.core.domain.model.PgpKey
+import com.cezila.hermes.core.domain.model.SignatureStatus
+import com.cezila.hermes.core.domain.repository.KeyRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DecryptAndVerifyUseCaseTest {
+
+    private val keyRepository: KeyRepository = mockk()
+    private val pgpDecryptor: PgpDecryptor = mockk()
+    private val useCase = DecryptAndVerifyUseCase(keyRepository, pgpDecryptor)
+
+    private val ownKey = PgpKey(
+        id = "0xMYKEY",
+        fingerprint = "AABBCCDDEEFF0011",
+        ownerName = "Alice",
+        ownerEmail = "alice@example.com",
+        algorithm = KeyAlgorithm.ED25519,
+        createdAt = 1_700_000_000_000L,
+        expiresAt = null,
+        isSecret = true,
+        armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nAlice\n-----END PGP PUBLIC KEY BLOCK-----",
+    )
+
+    private val contactKey = PgpKey(
+        id = "0xBOBKEY",
+        fingerprint = "1122334455667788",
+        ownerName = "Bob",
+        ownerEmail = "bob@example.com",
+        algorithm = KeyAlgorithm.RSA_4096,
+        createdAt = 1_700_000_000_000L,
+        expiresAt = null,
+        isSecret = false,
+        armoredPublicKey = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nBob\n-----END PGP PUBLIC KEY BLOCK-----",
+    )
+
+    private val armoredPrivateKey = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n-----END PGP PRIVATE KEY BLOCK-----"
+    private val ciphertext = "-----BEGIN PGP MESSAGE-----\nencrypted\n-----END PGP MESSAGE-----"
+    private val passphrase = "s3cr3t".toCharArray()
+
+    private val successResult = DecryptionResult(
+        plaintext = "Hello, Alice!",
+        plaintextBytes = null,
+        fileName = null,
+        signatureStatus = SignatureStatus.None,
+    )
+
+    @Test
+    fun invoke_textMode_success_returnsDecryptionResult() = runTest {
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.success(armoredPrivateKey)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(ownKey, contactKey))
+        coEvery {
+            pgpDecryptor.decryptAndVerify(ciphertext, armoredPrivateKey, passphrase, any())
+        } returns Result.success(successResult)
+
+        val result = useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = ciphertext,
+                fileBytes = null,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(successResult, result.getOrThrow())
+    }
+
+    @Test
+    fun invoke_fileMode_callsDecryptFileAndVerify() = runTest {
+        val fileBytes = "encrypted content".toByteArray()
+        val fileResult = DecryptionResult(
+            plaintext = "",
+            plaintextBytes = "plaintext".toByteArray(),
+            fileName = "document.pdf",
+            signatureStatus = SignatureStatus.None,
+        )
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.success(armoredPrivateKey)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(ownKey))
+        coEvery {
+            pgpDecryptor.decryptFileAndVerify(fileBytes, armoredPrivateKey, passphrase, any())
+        } returns Result.success(fileResult)
+
+        val result = useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = "",
+                fileBytes = fileBytes,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { pgpDecryptor.decryptFileAndVerify(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { pgpDecryptor.decryptAndVerify(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun invoke_textMode_callsDecryptAndVerify_notFile() = runTest {
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.success(armoredPrivateKey)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(ownKey))
+        coEvery {
+            pgpDecryptor.decryptAndVerify(ciphertext, armoredPrivateKey, passphrase, any())
+        } returns Result.success(successResult)
+
+        useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = ciphertext,
+                fileBytes = null,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        coVerify(exactly = 1) { pgpDecryptor.decryptAndVerify(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { pgpDecryptor.decryptFileAndVerify(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun invoke_whenPrivateKeyNotFound_propagatesFailureWithoutCallingDecryptor() = runTest {
+        val error = IllegalArgumentException("Key not found")
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.failure(error)
+
+        val result = useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = ciphertext,
+                fileBytes = null,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(error, result.exceptionOrNull())
+        coVerify(exactly = 0) { pgpDecryptor.decryptAndVerify(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun invoke_whenDecryptorFails_propagatesFailure() = runTest {
+        val error = RuntimeException("Wrong passphrase")
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.success(armoredPrivateKey)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(ownKey))
+        coEvery { pgpDecryptor.decryptAndVerify(any(), any(), any(), any()) } returns Result.failure(error)
+
+        val result = useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = ciphertext,
+                fileBytes = null,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun invoke_passesAllKnownPublicKeysToDecryptor() = runTest {
+        val knownKeysSlot = slot<List<String>>()
+        coEvery { keyRepository.getArmoredPrivateKey(ownKey.id) } returns Result.success(armoredPrivateKey)
+        every { keyRepository.getAllKeys() } returns flowOf(listOf(ownKey, contactKey))
+        coEvery {
+            pgpDecryptor.decryptAndVerify(any(), any(), any(), capture(knownKeysSlot))
+        } returns Result.success(successResult)
+
+        useCase(
+            DecryptAndVerifyUseCase.Params(
+                ciphertext = ciphertext,
+                fileBytes = null,
+                recipientKeyId = ownKey.id,
+                passphrase = passphrase,
+            )
+        )
+
+        val captured = knownKeysSlot.captured
+        assertTrue(captured.contains(ownKey.armoredPublicKey))
+        assertTrue(captured.contains(contactKey.armoredPublicKey))
+        assertEquals(2, captured.size)
+    }
+}


### PR DESCRIPTION
feat(crypto): implement PGP decrypt & verify with signature status #19 
Add full decryption pipeline: PgpDecryptor interface, BouncyCastlePgpDecryptor impl, DecryptAndVerifyUseCase, DecryptScreen/ViewModel/Contract (MVI), and navigation wiring. Signature verification produces a SignatureStatus so the UI can surface valid, invalid, unknown-signer, or unsigned results.