### PR TITLE
Merge fix/21-ed25519-x25519-encryption-subkey into develop

### DIFF
--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGenerator.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGenerator.kt
@@ -61,12 +61,16 @@ class BouncyCastlePgpKeyGenerator : PgpKeyGenerator {
         val encryptorBuilder = JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256)
             .setProvider(bcProvider)
 
+        // Ed25519 master key only signs/certifies; encryption is handled by a dedicated X25519 subkey.
+        // RSA master key handles everything (signing + encryption) in a single key.
+        val masterKeyFlags = if (algorithm == KeyAlgorithm.ED25519) {
+            KeyFlags.CERTIFY_OTHER or KeyFlags.SIGN_DATA
+        } else {
+            KeyFlags.CERTIFY_OTHER or KeyFlags.SIGN_DATA or KeyFlags.ENCRYPT_COMMS or KeyFlags.ENCRYPT_STORAGE
+        }
+
         val subpacketGen = PGPSignatureSubpacketGenerator().apply {
-            setKeyFlags(
-                false,
-                KeyFlags.CERTIFY_OTHER or KeyFlags.SIGN_DATA or
-                    KeyFlags.ENCRYPT_COMMS or KeyFlags.ENCRYPT_STORAGE,
-            )
+            setKeyFlags(false, masterKeyFlags)
             setPreferredSymmetricAlgorithms(
                 false,
                 intArrayOf(SymmetricKeyAlgorithmTags.AES_256, SymmetricKeyAlgorithmTags.AES_128),
@@ -88,6 +92,14 @@ class BouncyCastlePgpKeyGenerator : PgpKeyGenerator {
             signerBuilder,
             encryptorBuilder.build(passphrase),
         )
+
+        if (algorithm == KeyAlgorithm.ED25519) {
+            val encSubKeyPair = generateX25519KeyPair(creationDate)
+            val encSubpackets = PGPSignatureSubpacketGenerator().apply {
+                setKeyFlags(false, KeyFlags.ENCRYPT_COMMS or KeyFlags.ENCRYPT_STORAGE)
+            }.generate()
+            keyRingGenerator.addSubKey(encSubKeyPair, encSubpackets, null)
+        }
 
         val secretKeyRing = keyRingGenerator.generateSecretKeyRing()
         val publicKeyRing = keyRingGenerator.generatePublicKeyRing()
@@ -118,6 +130,12 @@ class BouncyCastlePgpKeyGenerator : PgpKeyGenerator {
         val kpg = KeyPairGenerator.getInstance("Ed25519", bcProvider)
         val javaKeyPair = kpg.generateKeyPair()
         return JcaPGPKeyPair(PGPPublicKey.EDDSA, javaKeyPair, creationDate)
+    }
+
+    private fun generateX25519KeyPair(creationDate: Date): PGPKeyPair {
+        val kpg = KeyPairGenerator.getInstance("X25519", bcProvider)
+        val javaKeyPair = kpg.generateKeyPair()
+        return JcaPGPKeyPair(PGPPublicKey.ECDH, javaKeyPair, creationDate)
     }
 
     private fun armorKeyRing(encode: (ArmoredOutputStream) -> Unit): String {

--- a/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptorTest.kt
+++ b/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpDecryptorTest.kt
@@ -18,11 +18,11 @@ class BouncyCastlePgpDecryptorTest {
     private val passphrase = "test-passphrase-123".toCharArray()
     private val plaintext = "Hello, this is a secret message!"
 
-    // RSA_4096 is used because the single-key ring it produces has isEncryptionKey=true,
-    // which is required by BouncyCastlePgpEncryptor.parseRecipientPublicKey.
-    // (Ed25519/EdDSA keys return isEncryptionKey=false regardless of key flags.)
     private suspend fun generateKeyMaterial(name: String, email: String) =
         generator.generate(name, email, KeyAlgorithm.RSA_4096, passphrase).getOrThrow()
+
+    private suspend fun generateEd25519KeyMaterial(name: String, email: String) =
+        generator.generate(name, email, KeyAlgorithm.ED25519, passphrase).getOrThrow()
 
     // --- Round-trip: text ---
 
@@ -207,6 +207,63 @@ class BouncyCastlePgpDecryptorTest {
 
         assertTrue(result.signatureStatus is SignatureStatus.Valid)
     }
+
+    // --- Ed25519 round-trip tests ---
+
+    @Test
+    fun encryptAndSign_ed25519RecipientKey_doesNotThrow() = runTest {
+        val alice = generateEd25519KeyMaterial("Alice", "alice@example.com")
+        val bob = generateEd25519KeyMaterial("Bob", "bob@example.com")
+        val result = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        )
+        assertTrue("Encrypt to Ed25519 key must succeed", result.isSuccess)
+    }
+
+    @Test
+    fun decryptAndVerify_ed25519Keys_roundTrip_returnsOriginalPlaintext() = runTest {
+        val alice = generateEd25519KeyMaterial("Alice", "alice@example.com")
+        val bob = generateEd25519KeyMaterial("Bob", "bob@example.com")
+        val ciphertext = encryptor.encryptAndSign(
+            plaintext = plaintext,
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+        val result = decryptor.decryptAndVerify(
+            ciphertext = ciphertext,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+        assertEquals(plaintext, result.plaintext)
+    }
+
+    @Test
+    fun decryptFileAndVerify_ed25519Keys_roundTrip_returnsOriginalBytes() = runTest {
+        val alice = generateEd25519KeyMaterial("Alice", "alice@example.com")
+        val bob = generateEd25519KeyMaterial("Bob", "bob@example.com")
+        val fileBytes = "secret file content".toByteArray()
+        val encrypted = encryptor.encryptFileAndSign(
+            bytes = fileBytes,
+            fileName = "secret.txt",
+            recipientArmoredPublicKey = alice.armoredPublicKey,
+            signerArmoredPrivateKey = bob.armoredPrivateKey,
+            passphrase = passphrase,
+        ).getOrThrow()
+        val result = decryptor.decryptFileAndVerify(
+            ciphertextBytes = encrypted,
+            recipientArmoredPrivateKey = alice.armoredPrivateKey,
+            passphrase = passphrase,
+            knownPublicKeys = listOf(bob.armoredPublicKey),
+        ).getOrThrow()
+        assertTrue(result.plaintextBytes!!.contentEquals(fileBytes))
+    }
+
+    // --- Round-trip: file (RSA) ---
 
     @Test
     fun decryptFileAndVerify_wrongPassphrase_returnsFailure() = runTest {

--- a/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGeneratorTest.kt
+++ b/core/data/src/test/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGeneratorTest.kt
@@ -2,6 +2,9 @@ package com.cezila.hermes.core.data.crypto
 
 import com.cezila.hermes.core.domain.model.KeyAlgorithm
 import kotlinx.coroutines.test.runTest
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+import org.bouncycastle.openpgp.PGPUtil
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -65,6 +68,30 @@ class BouncyCastlePgpKeyGeneratorTest {
     fun generate_ed25519_withEmptyPassphrase_doesNotThrow() = runTest {
         val result = generator.generate("Alice", "alice@example.com", KeyAlgorithm.ED25519, CharArray(0))
         assertTrue(result.isSuccess)
+    }
+
+    // --- Encryption capability tests ---
+
+    @Test
+    fun generate_ed25519_publicKeyRingContainsEncryptionCapableKey() = runTest {
+        val material = generator.generate("Alice", "alice@example.com", KeyAlgorithm.ED25519, passphrase).getOrThrow()
+        val inputStream = PGPUtil.getDecoderStream(material.armoredPublicKey.byteInputStream())
+        val collection = PGPPublicKeyRingCollection(inputStream, JcaKeyFingerprintCalculator())
+        val hasEncryptionKey = collection.keyRings.asSequence()
+            .flatMap { it.publicKeys.asSequence() }
+            .any { it.isEncryptionKey }
+        assertTrue("Ed25519 key ring must contain at least one encryption-capable key", hasEncryptionKey)
+    }
+
+    @Test
+    fun generate_rsa4096_publicKeyRingContainsEncryptionCapableKey() = runTest {
+        val material = generator.generate("Alice", "alice@example.com", KeyAlgorithm.RSA_4096, passphrase).getOrThrow()
+        val inputStream = PGPUtil.getDecoderStream(material.armoredPublicKey.byteInputStream())
+        val collection = PGPPublicKeyRingCollection(inputStream, JcaKeyFingerprintCalculator())
+        val hasEncryptionKey = collection.keyRings.asSequence()
+            .flatMap { it.publicKeys.asSequence() }
+            .any { it.isEncryptionKey }
+        assertTrue("RSA-4096 key ring must contain at least one encryption-capable key", hasEncryptionKey)
     }
 
     // --- RSA-4096 tests (slow) ---


### PR DESCRIPTION
fix(crypto): add X25519 encryption subkey to Ed25519 key rings #21 
Ed25519 master key now correctly carries only CERTIFY_OTHER | SIGN_DATA flags. A dedicated X25519 (ECDH) subkey is added for encryption, fixing encrypt/decrypt operations for Ed25519 recipients.