### PR TITLE
Merge fix/29-newapi-lint-ci-workflows into develop

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Run unit tests and lint
-        run: ./gradlew test lint
-
       - name: Decode keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,41 @@
+name: CI — Lint
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run lint
+        run: ./gradlew lint

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Run unit tests and lint
-        run: ./gradlew test lint
-
       - name: Decode keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -1,0 +1,41 @@
+name: CI — Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 > The quiet space for your digital truth.
 
+[![Lint](https://github.com/VitorCezila/hermes-android/actions/workflows/ci-lint.yml/badge.svg)](https://github.com/VitorCezila/hermes-android/actions/workflows/ci-lint.yml)
+[![Unit Tests](https://github.com/VitorCezila/hermes-android/actions/workflows/ci-unit-tests.yml/badge.svg)](https://github.com/VitorCezila/hermes-android/actions/workflows/ci-unit-tests.yml)
+
 A local PGP key manager for Android. Manage your cryptographic identities, encrypt messages, and verify signatures — entirely on your device, with no accounts, no cloud, and no backend.
 
 <p align="center">

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpEncryptor.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpEncryptor.kt
@@ -51,7 +51,7 @@ class BouncyCastlePgpEncryptor : PgpEncryptor {
                 output = armoredOut,
             )
         }
-        baos.toString(Charsets.UTF_8)
+        baos.toString(Charsets.UTF_8.name())
     }
 
     override suspend fun encryptFileAndSign(

--- a/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGenerator.kt
+++ b/core/data/src/main/kotlin/com/cezila/hermes/core/data/crypto/BouncyCastlePgpKeyGenerator.kt
@@ -148,6 +148,6 @@ class BouncyCastlePgpKeyGenerator : PgpKeyGenerator {
     private fun armorKeyRing(encode: (ArmoredOutputStream) -> Unit): String {
         val baos = ByteArrayOutputStream()
         ArmoredOutputStream(baos).use { encode(it) }
-        return baos.toString(Charsets.UTF_8)
+        return baos.toString(Charsets.UTF_8.name())
     }
 }


### PR DESCRIPTION
fix(ci): fix NewApi lint errors and add dedicated lint/test workflows #29 
- Replace ByteArrayOutputStream.toString(Charset) with toString(String) in BouncyCastlePgpEncryptor and BouncyCastlePgpKeyGenerator to fix NewApi lint errors (API 33 vs minSdk 24)
- Add ci-lint.yml and ci-unit-tests.yml as separate workflows for independent status badges on push/PR to main and develop
- Remove duplicate test+lint step from ci-develop.yml and ci-main.yml
- Add Lint and Unit Tests badges to README